### PR TITLE
frontend: Specify volume for CACHE_DIR

### DIFF
--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -5,7 +5,7 @@ set -e
 #
 # CPU: 2
 # Memory: 4GB
-# Disk: 1GB / non-persistent SSD (only for read-only config file)
+# Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
 # Ports exposed to other Sourcegraph services: 3090
@@ -22,6 +22,7 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e REPO_UPDATER_URL=http://repo-updater:3182 \
     -e ZOEKT_HOST=zoekt-webserver:6070 \
+    -v ~/sourcegraph-docker/sourcegraph-frontend-internal-disk:/mnt/cache \
     sourcegraph/frontend:3.0.0-beta.2
 
 echo "Deployed sourcegraph-frontend-internal service"

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -5,7 +5,7 @@ set -e
 #
 # CPU: 2
 # Memory: 4GB
-# Disk: 1GB / non-persistent SSD (only for read-only config file)
+# Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: HTTP GET http://sourcegraph-frontend:3080/healthz
 # Ports exposed to other Sourcegraph services: none
@@ -22,6 +22,7 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e REPO_UPDATER_URL=http://repo-updater:3182 \
     -e ZOEKT_HOST=zoekt-webserver:6070 \
+    -v ~/sourcegraph-docker/sourcegraph-frontend-disk:/mnt/cache \
     -p 127.0.0.1:3080:3080 \
     sourcegraph/frontend:3.0.0-beta.2
 


### PR DESCRIPTION
The raw endpoint downloads archives to the local disk. These files can be
large, as such we mount a volume to avoid exhausting the usually low container
disk space.

Part of https://github.com/sourcegraph/sourcegraph/issues/1913