### PR TITLE
Add standardized Jaeger tracing + Grafana/Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ To scale the cluster deployment, you will need to:
 2. [Configure the `frontend` and `frontend-internal` to communicate with the new instances.](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/f01b97a397138dd76e5f5ed45b2574b9a2e70cd1/deploy-frontend.sh#L31-L34)
 3. You're done! You do not need to configure or restart any other services.
 
+## Metrics and Tracing
+
+This deployment comes with metrics and tracing built-in. See [metrics and tracing](metrics-and-tracing.md) for details.
+
 ## Configuring HTTPS
 
 See https://docs.sourcegraph.com/admin/nginx#nginx-for-other-sourcegraph-clusters-e-g-pure-docker

--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -24,6 +24,6 @@ docker run --detach \
     -e REPO_UPDATER_URL=http://repo-updater:3182 \
     -e ZOEKT_HOST=zoekt-webserver:6070 \
     -v ~/sourcegraph-docker/sourcegraph-frontend-internal-0-disk:/mnt/cache \
-    sourcegraph/frontend:3.2.1-rc.1
+    sourcegraph/frontend:3.2.1
 
 echo "Deployed sourcegraph-frontend-internal service"

--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
-# Ports exposed to other Sourcegraph services: 3090
+# Ports exposed to other Sourcegraph services: 3090/TCP 6060/TCP
 # Ports exposed to the public internet: none
 #
 docker run --detach \

--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -24,6 +24,6 @@ docker run --detach \
     -e REPO_UPDATER_URL=http://repo-updater:3182 \
     -e ZOEKT_HOST=zoekt-webserver:6070 \
     -v ~/sourcegraph-docker/sourcegraph-frontend-internal-0-disk:/mnt/cache \
-    sourcegraph/frontend:3.2.0
+    sourcegraph/frontend:3.2.1-rc.1
 
 echo "Deployed sourcegraph-frontend-internal service"

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -26,7 +26,7 @@ docker run --detach \
     -e ZOEKT_HOST=zoekt-webserver:6070 \
     -v ~/sourcegraph-docker/sourcegraph-frontend-0-disk:/mnt/cache \
     -p 0.0.0.0:3080:3080 \
-    sourcegraph/frontend:3.2.1-rc.1
+    sourcegraph/frontend:3.2.1
 
 # Note: SRC_GIT_SERVERS, SEARCHER_URL, and SYMBOLS_URL are space-separated
 # lists which each allow you to specify more container instances for scaling

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -26,7 +26,7 @@ docker run --detach \
     -e ZOEKT_HOST=zoekt-webserver:6070 \
     -v ~/sourcegraph-docker/sourcegraph-frontend-0-disk:/mnt/cache \
     -p 0.0.0.0:3080:3080 \
-    sourcegraph/frontend:3.2.0
+    sourcegraph/frontend:3.2.1-rc.1
 
 # Note: SRC_GIT_SERVERS, SEARCHER_URL, and SYMBOLS_URL are space-separated
 # lists which each allow you to specify more container instances for scaling

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: HTTP GET http://sourcegraph-frontend:3080/healthz
-# Ports exposed to other Sourcegraph services: none
+# Ports exposed to other Sourcegraph services: 6060/TCP
 # Ports exposed to the public internet: 3080 (HTTP) and/or 3443 (HTTPS)
 #
 docker run --detach \

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -15,6 +15,7 @@ docker run --detach \
     --name=sourcegraph-frontend \
     --network=sourcegraph \
     --restart=always \
+    -e JAEGER_AGENT_HOST='jaeger-agent' \
     -e PGHOST=pgsql \
     -e SRC_GIT_SERVERS=gitserver-0:3178 \
     -e SRC_SYNTECT_SERVER=http://syntect-server:9238 \

--- a/deploy-github-proxy.sh
+++ b/deploy-github-proxy.sh
@@ -17,6 +17,6 @@ docker run --detach \
     --restart=always \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
-    sourcegraph/github-proxy:3.2.0
+    sourcegraph/github-proxy:3.2.1-rc.1
 
 echo "Deployed github-proxy service"

--- a/deploy-github-proxy.sh
+++ b/deploy-github-proxy.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 1GB / non-persistent SSD (only for read-only config file)
 # Network: 100mbps
 # Liveness probe: n/a
-# Ports exposed to other Sourcegraph services: 3180/TCP
+# Ports exposed to other Sourcegraph services: 3180/TCP 6060/TCP
 # Ports exposed to the public internet: none
 #
 docker run --detach \

--- a/deploy-github-proxy.sh
+++ b/deploy-github-proxy.sh
@@ -17,6 +17,6 @@ docker run --detach \
     --restart=always \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
-    sourcegraph/github-proxy:3.2.1-rc.1
+    sourcegraph/github-proxy:3.2.1
 
 echo "Deployed github-proxy service"

--- a/deploy-github-proxy.sh
+++ b/deploy-github-proxy.sh
@@ -16,6 +16,7 @@ docker run --detach \
     --network=sourcegraph \
     --restart=always \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
+    -e JAEGER_AGENT_HOST='jaeger-agent' \
     sourcegraph/github-proxy:3.2.0
 
 echo "Deployed github-proxy service"

--- a/deploy-gitserver.sh
+++ b/deploy-gitserver.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 200GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
-# Ports exposed to other Sourcegraph services: 3182/TCP
+# Ports exposed to other Sourcegraph services: 3182/TCP 6060/TCP
 # Ports exposed to the public internet: none
 #
 docker run --detach \

--- a/deploy-gitserver.sh
+++ b/deploy-gitserver.sh
@@ -16,6 +16,7 @@ docker run --detach \
     --network=sourcegraph \
     --restart=always \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
+    -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/gitserver-0-disk:/data/repos \
     sourcegraph/gitserver:3.2.0
 

--- a/deploy-gitserver.sh
+++ b/deploy-gitserver.sh
@@ -18,6 +18,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/gitserver-0-disk:/data/repos \
-    sourcegraph/gitserver:3.2.0
+    sourcegraph/gitserver:3.2.1-rc.1
 
 echo "Deployed gitserver service"

--- a/deploy-gitserver.sh
+++ b/deploy-gitserver.sh
@@ -18,6 +18,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/gitserver-0-disk:/data/repos \
-    sourcegraph/gitserver:3.2.1-rc.1
+    sourcegraph/gitserver:3.2.1
 
 echo "Deployed gitserver service"

--- a/deploy-grafana.sh
+++ b/deploy-grafana.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+# Description: Dashboards and graphs for Prometheus metrics.
+#
+# CPU: 1
+# Memory: 1GB
+# Disk: 100GB / persistent SSD
+# Network: 100mbps
+# Liveness probe: n/a
+# Ports exposed to other Sourcegraph services: none
+# Ports exposed to the public internet: none (HTTP 3000 should be exposed to admins only)
+#
+docker run --detach \
+    --name=grafana \
+    --network=sourcegraph \
+    --restart=always \
+    -p 0.0.0.0:3000:3000 \
+    -v ~/sourcegraph-docker/grafana-disk:/var/lib/grafana \
+    -v $(pwd)/grafana:/etc/grafana \
+    -e GF_AUTH_ANONYMOUS_ENABLED=true \
+    -e GF_AUTH_ANONYMOUS_ORG_NAME=Sourcegraph \
+    -e GF_AUTH_ANONYMOUS_ORG_ROLE=Editor \
+    -e GF_USERS_ALLOW_SIGN_UP='false' \
+    -e GF_USERS_AUTO_ASSIGN_ORG='true' \
+    -e GF_USERS_AUTO_ASSIGN_ORG_ROLE=Editor \
+    grafana/grafana:6.1.1@sha256:e7a513bf7f33ef9681b2d35a799136e1ce9330f9055f75dfa2101d812946184b
+
+# Add the following lines above if you wish to use an auth proxy with Grafana:
+#
+# -e GF_AUTH_PROXY_ENABLED=true \
+# -e GF_AUTH_PROXY_HEADER_NAME='X-Forwarded-User' \
+# -e GF_SERVER_ROOT_URL='https://grafana.example.com' \

--- a/deploy-jaeger-agent.sh
+++ b/deploy-jaeger-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# Description: Jaeger agent which is local to the host machine (containers on
+# the machine send trace information to it and it relays to the collector).
+#
+# CPU: 1
+# Memory: 1GB
+# Disk: none
+# Network: 100mbps
+# Liveness probe: n/a
+# Ports exposed to other Sourcegraph services: 5775/UDP 6831/UDP 6832/UDP (on the same host machine)
+# Ports exposed to the public internet: none
+#
+docker run --detach \
+    --name=jaeger-agent \
+    --network=sourcegraph \
+    --restart=always \
+    -e COLLECTOR_HOST_PORT='jaeger-collector:14267' \
+    jaegertracing/jaeger-agent@sha256:7ad33c19fd66307f2a3c07c95eb07c335ddce1b487f6b6128faa75d042c496cb

--- a/deploy-jaeger-cassandra.sh
+++ b/deploy-jaeger-cassandra.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+# Description: Jaeger's Cassandra database for storing traces.
+#
+# CPU: 4
+# Memory: 8GB
+# Disk: 128GB / persistent SSD
+# Network: 100mbps
+# Liveness probe: n/a
+# Ports exposed to other Sourcegraph services: 9042/TCP
+# Ports exposed to the public internet: none
+#
+docker run --detach \
+    --name=jaeger-cassandra \
+    --network=sourcegraph \
+    --restart=always \
+    -e HEAP_NEWSIZE='1G' \
+    -e MAX_HEAP_SIZE='6G' \
+    -e CASSANDRA_DC='sourcegraph' \
+    -e CASSANDRA_RACK='rack1' \
+    -e CASSANDRA_ENDPOINT_SNITCH='GossipingPropertyFileSnitch' \
+    -v ~/sourcegraph-docker/jaeger-cassandra-disk/:/var/lib/cassandra \
+    cassandra:3.11.4@sha256:9f1d47fd23261c49f226546fe0134e6d4ad0570b7ea3a169c521005cb8369a32
+
+echo "Deployed jaeger-cassandra service"

--- a/deploy-jaeger-collector.sh
+++ b/deploy-jaeger-collector.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+# Description: Receives traces from Jaeger agents.
+#
+# CPU: 1
+# Memory: 1GB
+# Disk: none
+# Network: 100mbps
+# Liveness probe: n/a
+# Ports exposed to other Sourcegraph services: 14267/TCP
+# Ports exposed to the public internet: none
+#
+docker run --detach \
+    --name=jaeger-collector \
+    --network=sourcegraph \
+    --restart=always \
+    -e SPAN_STORAGE_TYPE=cassandra \
+    -e CASSANDRA_SERVERS=jaeger-cassandra \
+    -e CASSANDRA_KEYSPACE=jaeger_v1_sourcegraph \
+    jaegertracing/jaeger-collector:1.11@sha256:0b6d28bb52410f7b50c0f0fc16d7ee391e2e3eca47b713ac88d0891ca8a63cb9
+
+echo "Deployed jaeger-collector service"

--- a/deploy-jaeger-query.sh
+++ b/deploy-jaeger-query.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+# Description: Jaeger frontend for querying traces.
+#
+# CPU: 1
+# Memory: 1GB
+# Disk: none
+# Network: 100mbps
+# Liveness probe: n/a
+# Ports exposed to other Sourcegraph services: none
+# Ports exposed to the public internet: none (HTTP 16686 should be exposed to admins only)
+#
+docker run --detach \
+    --name=jaeger-query \
+    --network=sourcegraph \
+    --restart=always \
+    -p 0.0.0.0:16686:16686 \
+    -e SPAN_STORAGE_TYPE=cassandra \
+    -e CASSANDRA_SERVERS=jaeger-cassandra \
+    -e CASSANDRA_KEYSPACE=jaeger_v1_sourcegraph \
+    -e CASSANDRA_LOCAL_DC=sourcegraph \
+    jaegertracing/jaeger-query:1.11@sha256:cddc521d0166c868931282685a863368ae2c14c4de0c1be38e388ece3080439e

--- a/deploy-management-console.sh
+++ b/deploy-management-console.sh
@@ -18,6 +18,6 @@ docker run --detach \
     -v ~/sourcegraph-docker/management-console-disk:/etc/sourcegraph \
     -e PGHOST=pgsql \
     -p 0.0.0.0:2633:2633 \
-    sourcegraph/management-console:3.2.0
+    sourcegraph/management-console:3.2.1-rc.1
 
 echo "Deployed management-console service"

--- a/deploy-management-console.sh
+++ b/deploy-management-console.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 1GB / persistent (can be discarded, only contains self-signed TLS cert)
 # Network: 100mbps
 # Liveness probe: n/a
-# Ports exposed to other Sourcegraph services: none
+# Ports exposed to other Sourcegraph services: 6060/TCP
 # Ports exposed to the public internet: 2633 (HTTPS); optionally behind a firewall for extra security
 #
 docker run --detach \

--- a/deploy-management-console.sh
+++ b/deploy-management-console.sh
@@ -18,6 +18,6 @@ docker run --detach \
     -v ~/sourcegraph-docker/management-console-disk:/etc/sourcegraph \
     -e PGHOST=pgsql \
     -p 0.0.0.0:2633:2633 \
-    sourcegraph/management-console:3.2.1-rc.1
+    sourcegraph/management-console:3.2.1
 
 echo "Deployed management-console service"

--- a/deploy-pgsql.sh
+++ b/deploy-pgsql.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 128GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: 5432/TCP
-# Ports exposed to other Sourcegraph services: 5432/TCP
+# Ports exposed to other Sourcegraph services: 5432/TCP 9187/TCP
 # Ports exposed to the public internet: none
 #
 docker run --detach \

--- a/deploy-prometheus.sh
+++ b/deploy-prometheus.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+# Description: Prometheus collects metrics and aggregates them into graphs.
+#
+# CPU: 4
+# Memory: 8GB
+# Disk: 200GB / persistent SSD
+# Network: 100mbps
+# Liveness probe: n/a
+# Ports exposed to other Sourcegraph services: none
+# Ports exposed to the public internet: none (HTTP 9090 should be exposed to admins only)
+#
+docker run --detach \
+    --name=prometheus \
+    --network=sourcegraph \
+    --restart=always \
+    -p 0.0.0.0:9090:9090 \
+    -v ~/sourcegraph-docker/prometheus-disk:/prometheus-data \
+    -v $(pwd)/prometheus:/etc/prometheus \
+    sourcegraph/prometheus:v1.4.1@sha256:1a02878ac9a0f532a68673bda93d406b21786706446c42a40cb3ed3e867278c0 \
+    -config.file=/etc/prometheus/prometheus.yml \
+    -storage.local.path=/prometheus-data \
+    -web.console.libraries=/etc/prometheus/console_libraries \
+    -web.console.templates=/etc/prometheus/consoles

--- a/deploy-query-runner.sh
+++ b/deploy-query-runner.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 1GB / non-persistent SSD (only for read-only config file)
 # Network: 100mbps
 # Liveness probe: n/a
-# Ports exposed to other Sourcegraph services: 3183/TCP
+# Ports exposed to other Sourcegraph services: 3183/TCP 6060/TCP
 # Ports exposed to the public internet: none
 #
 docker run --detach \

--- a/deploy-query-runner.sh
+++ b/deploy-query-runner.sh
@@ -17,6 +17,6 @@ docker run --detach \
     --restart=always \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
-    sourcegraph/query-runner:3.2.0
+    sourcegraph/query-runner:3.2.1-rc.1
 
 echo "Deployed query-runner service"

--- a/deploy-query-runner.sh
+++ b/deploy-query-runner.sh
@@ -16,6 +16,7 @@ docker run --detach \
     --network=sourcegraph \
     --restart=always \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
+    -e JAEGER_AGENT_HOST='jaeger-agent' \
     sourcegraph/query-runner:3.2.0
 
 echo "Deployed query-runner service"

--- a/deploy-query-runner.sh
+++ b/deploy-query-runner.sh
@@ -17,6 +17,6 @@ docker run --detach \
     --restart=always \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
-    sourcegraph/query-runner:3.2.1-rc.1
+    sourcegraph/query-runner:3.2.1
 
 echo "Deployed query-runner service"

--- a/deploy-redis-cache.sh
+++ b/deploy-redis-cache.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 128GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: 6379/TCP
-# Ports exposed to other Sourcegraph services: 6379/TCP
+# Ports exposed to other Sourcegraph services: 6379/TCP 9121/TCP
 # Ports exposed to the public internet: none
 #
 docker run --detach \

--- a/deploy-redis-store.sh
+++ b/deploy-redis-store.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 128GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: 6379/TCP
-# Ports exposed to other Sourcegraph services: 6379/TCP
+# Ports exposed to other Sourcegraph services: 6379/TCP 9121/TCP
 # Ports exposed to the public internet: none
 #
 docker run --detach \

--- a/deploy-repo-updater.sh
+++ b/deploy-repo-updater.sh
@@ -16,6 +16,7 @@ docker run --detach \
     --network=sourcegraph \
     --restart=always \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
+    -e JAEGER_AGENT_HOST='jaeger-agent' \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \
     -v ~/sourcegraph-docker/repo-updater-disk:/mnt/cache \
     sourcegraph/repo-updater:3.2.0

--- a/deploy-repo-updater.sh
+++ b/deploy-repo-updater.sh
@@ -19,6 +19,6 @@ docker run --detach \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \
     -v ~/sourcegraph-docker/repo-updater-disk:/mnt/cache \
-    sourcegraph/repo-updater:3.2.0
+    sourcegraph/repo-updater:3.2.1-rc.1
 
 echo "Deployed repo-updater service"

--- a/deploy-repo-updater.sh
+++ b/deploy-repo-updater.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
-# Ports exposed to other Sourcegraph services: 3182/TCP
+# Ports exposed to other Sourcegraph services: 3182/TCP 6060/TCP
 # Ports exposed to the public internet: none
 #
 docker run --detach \

--- a/deploy-repo-updater.sh
+++ b/deploy-repo-updater.sh
@@ -19,6 +19,6 @@ docker run --detach \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \
     -v ~/sourcegraph-docker/repo-updater-disk:/mnt/cache \
-    sourcegraph/repo-updater:3.2.1-rc.1
+    sourcegraph/repo-updater:3.2.1
 
 echo "Deployed repo-updater service"

--- a/deploy-searcher.sh
+++ b/deploy-searcher.sh
@@ -18,6 +18,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/searcher-0-disk:/mnt/cache \
-    sourcegraph/searcher:3.2.0
+    sourcegraph/searcher:3.2.1-rc.1
 
 echo "Deployed searcher service"

--- a/deploy-searcher.sh
+++ b/deploy-searcher.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: HTTP GET http://searcher:3181/healthz
-# Ports exposed to other Sourcegraph services: 3181/TCP
+# Ports exposed to other Sourcegraph services: 3181/TCP 6060/TCP
 # Ports exposed to the public internet: none
 #
 docker run --detach \

--- a/deploy-searcher.sh
+++ b/deploy-searcher.sh
@@ -18,6 +18,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/searcher-0-disk:/mnt/cache \
-    sourcegraph/searcher:3.2.1-rc.1
+    sourcegraph/searcher:3.2.1
 
 echo "Deployed searcher service"

--- a/deploy-searcher.sh
+++ b/deploy-searcher.sh
@@ -16,6 +16,7 @@ docker run --detach \
     --network=sourcegraph \
     --restart=always \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
+    -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/searcher-0-disk:/mnt/cache \
     sourcegraph/searcher:3.2.0
 

--- a/deploy-symbols.sh
+++ b/deploy-symbols.sh
@@ -18,6 +18,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/symbols-0-disk:/mnt/cache \
-    sourcegraph/symbols:3.2.0
+    sourcegraph/symbols:3.2.1-rc.1
 
 echo "Deployed symbols service"

--- a/deploy-symbols.sh
+++ b/deploy-symbols.sh
@@ -16,6 +16,7 @@ docker run --detach \
     --network=sourcegraph \
     --restart=always \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
+    -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/symbols-0-disk:/mnt/cache \
     sourcegraph/symbols:3.2.0
 

--- a/deploy-symbols.sh
+++ b/deploy-symbols.sh
@@ -8,7 +8,7 @@ set -e
 # Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: none
-# Ports exposed to other Sourcegraph services: 3184/TCP
+# Ports exposed to other Sourcegraph services: 3184/TCP 6060/TCP
 # Ports exposed to the public internet: none
 #
 docker run --detach \

--- a/deploy-symbols.sh
+++ b/deploy-symbols.sh
@@ -18,6 +18,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/symbols-0-disk:/mnt/cache \
-    sourcegraph/symbols:3.2.1-rc.1
+    sourcegraph/symbols:3.2.1
 
 echo "Deployed symbols service"

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,7 @@ docker network create sourcegraph &> /dev/null || true
 
 ./deploy-github-proxy.sh
 ./deploy-gitserver.sh
+./deploy-grafana.sh
 ./deploy-jaeger-agent.sh
 ./deploy-jaeger-cassandra.sh
 ./deploy-jaeger-collector.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,6 +14,7 @@ docker network create sourcegraph &> /dev/null || true
 ./init-jaeger-cassandra-schema.sh
 ./deploy-management-console.sh
 ./deploy-pgsql.sh
+./deploy-prometheus.sh
 ./deploy-query-runner.sh
 ./deploy-redis-cache.sh
 ./deploy-redis-store.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,11 @@ docker network create sourcegraph &> /dev/null || true
 
 ./deploy-github-proxy.sh
 ./deploy-gitserver.sh
+./deploy-jaeger-agent.sh
+./deploy-jaeger-cassandra.sh
+./deploy-jaeger-collector.sh
+./deploy-jaeger-query.sh
+./init-jaeger-cassandra-schema.sh
 ./deploy-management-console.sh
 ./deploy-pgsql.sh
 ./deploy-query-runner.sh

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,6 @@
+# Grafana configuration
+
+This directory contains configuration for the [Grafana](https://grafana.com/) dashboards deployment.
+
+This directory is mounted into the `grafana` container. After making your changes to this directory,
+simply `docker restart grafana` for your changes to take effect.

--- a/grafana/grafana.ini
+++ b/grafana/grafana.ini
@@ -1,0 +1,536 @@
+##################### Grafana Configuration Example #####################
+#
+# Everything has defaults so you only need to uncomment things you want to
+# change
+
+# possible values : production, development
+;app_mode = production
+
+# instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
+;instance_name = ${HOSTNAME}
+
+#################################### Paths ####################################
+[paths]
+# Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
+;data = /var/lib/grafana
+
+# Temporary files in `data` directory older than given duration will be removed
+;temp_data_lifetime = 24h
+
+# Directory where grafana can store logs
+;logs = /var/log/grafana
+
+# Directory where grafana will automatically scan and look for plugins
+;plugins = /var/lib/grafana/plugins
+
+# folder that contains provisioning config files that grafana will apply on startup and while running.
+;provisioning = conf/provisioning
+
+#################################### Server ####################################
+[server]
+# Protocol (http, https, socket)
+;protocol = http
+
+# The ip address to bind to, empty will bind to all interfaces
+;http_addr =
+
+# The http port  to use
+;http_port = 3000
+
+# The public facing domain name used to access grafana from a browser
+;domain = localhost
+
+# Redirect to correct domain if host header does not match domain
+# Prevents DNS rebinding attacks
+;enforce_domain = false
+
+# The full public facing url you use in browser, used for redirects and emails
+# If you use reverse proxy and sub path specify full url (with sub path)
+;root_url = http://localhost:3000
+
+# Log web requests
+;router_logging = false
+
+# the path relative working path
+;static_root_path = public
+
+# enable gzip
+;enable_gzip = false
+
+# https certs & key file
+;cert_file =
+;cert_key =
+
+# Unix socket path
+;socket =
+
+#################################### Database ####################################
+[database]
+# You can configure the database connection by specifying type, host, name, user and password
+# as separate properties or as on string using the url properties.
+
+# Either "mysql", "postgres" or "sqlite3", it's your choice
+;type = sqlite3
+;host = 127.0.0.1:3306
+;name = grafana
+;user = root
+# If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
+;password =
+
+# Use either URL or the previous fields to configure the database
+# Example: mysql://user:secret@host:port/database
+;url =
+
+# For "postgres" only, either "disable", "require" or "verify-full"
+;ssl_mode = disable
+
+# For "sqlite3" only, path relative to data_path setting
+;path = grafana.db
+
+# Max idle conn setting default is 2
+;max_idle_conn = 2
+
+# Max conn setting default is 0 (mean not set)
+;max_open_conn =
+
+# Connection Max Lifetime default is 14400 (means 14400 seconds or 4 hours)
+;conn_max_lifetime = 14400
+
+# Set to true to log the sql calls and execution times.
+log_queries =
+
+# For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
+;cache_mode = private
+
+#################################### Cache server #############################
+[remote_cache]
+# Either "redis", "memcached" or "database" default is "database"
+;type = database
+
+# cache connectionstring options
+# database: will use Grafana primary database.
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
+# memcache: 127.0.0.1:11211
+;connstr =
+
+#################################### Session ####################################
+[session]
+# Either "memory", "file", "redis", "mysql", "postgres", default is "file"
+;provider = file
+
+# Provider config options
+# memory: not have any config yet
+# file: session dir path, is relative to grafana data_path
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
+# mysql: go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1:3306)/database_name`
+# postgres: user=a password=b host=localhost port=5432 dbname=c sslmode=disable
+;provider_config = sessions
+
+# Session cookie name
+;cookie_name = grafana_sess
+
+# If you use session in https only, default is false
+;cookie_secure = false
+
+# Session life time, default is 86400
+;session_life_time = 86400
+
+#################################### Data proxy ###########################
+[dataproxy]
+
+# This enables data proxy logging, default is false
+;logging = false
+
+# How long the data proxy should wait before timing out default is 30 (seconds)
+;timeout = 30
+
+# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
+;send_user_header = false
+
+#################################### Analytics ####################################
+[analytics]
+# Server reporting, sends usage counters to stats.grafana.org every 24 hours.
+# No ip addresses are being tracked, only simple counters to track
+# running instances, dashboard and error counts. It is very helpful to us.
+# Change this option to false to disable reporting.
+;reporting_enabled = true
+
+# Set to false to disable all checks to https://grafana.net
+# for new vesions (grafana itself and plugins), check is used
+# in some UI views to notify that grafana or plugin update exists
+# This option does not cause any auto updates, nor send any information
+# only a GET request to http://grafana.com to get latest versions
+;check_for_updates = true
+
+# Google Analytics universal tracking code, only enabled if you specify an id here
+;google_analytics_ua_id =
+
+# Google Tag Manager ID, only enabled if you specify an id here
+;google_tag_manager_id =
+
+#################################### Security ####################################
+[security]
+# default admin user, created on startup
+;admin_user = admin
+
+# default admin password, can be changed before first start of grafana,  or in profile settings
+;admin_password = admin
+
+# used for signing
+;secret_key = SW2YcwTIb9zpOOhoPsMm
+
+# disable gravatar profile images
+;disable_gravatar = false
+
+# data source proxy whitelist (ip_or_domain:port separated by spaces)
+;data_source_proxy_whitelist =
+
+# disable protection against brute force login attempts
+;disable_brute_force_login_protection = false
+
+# set to true if you host Grafana behind HTTPS. default is false.
+;cookie_secure = false
+
+# set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict" and "none"
+;cookie_samesite = lax
+
+#################################### Snapshots ###########################
+[snapshots]
+# snapshot sharing options
+;external_enabled = true
+;external_snapshot_url = https://snapshots-origin.raintank.io
+;external_snapshot_name = Publish to snapshot.raintank.io
+
+# remove expired snapshot
+;snapshot_remove_expired = true
+
+#################################### Dashboards History ##################
+[dashboards]
+# Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
+;versions_to_keep = 20
+
+#################################### Users ###############################
+[users]
+# disable user signup / registration
+;allow_sign_up = true
+
+# Allow non admin users to create organizations
+;allow_org_create = true
+
+# Set to true to automatically assign new users to the default organization (id 1)
+;auto_assign_org = true
+
+# Default role new users will be automatically assigned (if disabled above is set to true)
+;auto_assign_org_role = Viewer
+
+# Background text for the user field on the login page
+;login_hint = email or username
+;password_hint = password
+
+# Default UI theme ("dark" or "light")
+;default_theme = dark
+
+# External user management, these options affect the organization users view
+;external_manage_link_url =
+;external_manage_link_name =
+;external_manage_info =
+
+# Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
+;viewers_can_edit = false
+
+# Editors can administrate dashboard, folders and teams they create
+;editors_can_admin = false
+
+[auth]
+# Login cookie name
+;login_cookie_name = grafana_session
+
+# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days,
+;login_maximum_inactive_lifetime_days = 7
+
+# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+;login_maximum_lifetime_days = 30
+
+# How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+;token_rotation_interval_minutes = 10
+
+# Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
+;disable_login_form = false
+
+# Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
+;disable_signout_menu = false
+
+# URL to redirect the user to after sign out
+;signout_redirect_url =
+
+# Set to true to attempt login with OAuth automatically, skipping the login screen.
+# This setting is ignored if multiple OAuth providers are configured.
+;oauth_auto_login = false
+
+#################################### Anonymous Auth ######################
+[auth.anonymous]
+# enable anonymous access
+;enabled = false
+
+# specify organization name that should be used for unauthenticated users
+;org_name = Main Org.
+
+# specify role for unauthenticated users
+;org_role = Viewer
+
+#################################### Github Auth ##########################
+[auth.github]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email,read:org
+;auth_url = https://github.com/login/oauth/authorize
+;token_url = https://github.com/login/oauth/access_token
+;api_url = https://api.github.com/user
+;team_ids =
+;allowed_organizations =
+
+#################################### Google Auth ##########################
+[auth.google]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_client_id
+;client_secret = some_client_secret
+;scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
+;auth_url = https://accounts.google.com/o/oauth2/auth
+;token_url = https://accounts.google.com/o/oauth2/token
+;api_url = https://www.googleapis.com/oauth2/v1/userinfo
+;allowed_domains =
+
+#################################### Generic OAuth ##########################
+[auth.generic_oauth]
+;enabled = false
+;name = OAuth
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email,read:org
+;auth_url = https://foo.bar/login/oauth/authorize
+;token_url = https://foo.bar/login/oauth/access_token
+;api_url = https://foo.bar/user
+;team_ids =
+;allowed_organizations =
+;tls_skip_verify_insecure = false
+;tls_client_cert =
+;tls_client_key =
+;tls_client_ca =
+
+; Set to true to enable sending client_id and client_secret via POST body instead of Basic authentication HTTP header
+; This might be required if the OAuth provider is not RFC6749 compliant, only supporting credentials passed via POST payload
+;send_client_credentials_via_post = false
+
+#################################### Grafana.com Auth ####################
+[auth.grafana_com]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email
+;allowed_organizations =
+
+#################################### Auth Proxy ##########################
+[auth.proxy]
+;enabled = false
+;header_name = X-WEBAUTH-USER
+;header_property = username
+;auto_sign_up = true
+;ldap_sync_ttl = 60
+;whitelist = 192.168.1.1, 192.168.2.1
+;headers = Email:X-User-Email, Name:X-User-Name
+
+#################################### Basic Auth ##########################
+[auth.basic]
+;enabled = true
+
+#################################### Auth LDAP ##########################
+[auth.ldap]
+;enabled = false
+;config_file = /etc/grafana/ldap.toml
+;allow_sign_up = true
+
+#################################### SMTP / Emailing ##########################
+[smtp]
+;enabled = false
+;host = localhost:25
+;user =
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
+;password =
+;cert_file =
+;key_file =
+;skip_verify = false
+;from_address = admin@grafana.localhost
+;from_name = Grafana
+# EHLO identity in SMTP dialog (defaults to instance_name)
+;ehlo_identity = dashboard.example.com
+
+[emails]
+;welcome_email_on_sign_up = false
+
+#################################### Logging ##########################
+[log]
+# Either "console", "file", "syslog". Default is console and  file
+# Use space to separate multiple modes, e.g. "console file"
+;mode = console file
+
+# Either "debug", "info", "warn", "error", "critical", default is "info"
+;level = info
+
+# optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
+;filters =
+
+# For "console" mode only
+[log.console]
+;level =
+
+# log line format, valid options are text, console and json
+;format = console
+
+# For "file" mode only
+[log.file]
+;level =
+
+# log line format, valid options are text, console and json
+;format = text
+
+# This enables automated log rotate(switch of following options), default is true
+;log_rotate = true
+
+# Max line number of single file, default is 1000000
+;max_lines = 1000000
+
+# Max size shift of single file, default is 28 means 1 << 28, 256MB
+;max_size_shift = 28
+
+# Segment log daily, default is true
+;daily_rotate = true
+
+# Expired days of log file(delete after max days), default is 7
+;max_days = 7
+
+[log.syslog]
+;level =
+
+# log line format, valid options are text, console and json
+;format = text
+
+# Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
+;network =
+;address =
+
+# Syslog facility. user, daemon and local0 through local7 are valid.
+;facility =
+
+# Syslog tag. By default, the process' argv[0] is used.
+;tag =
+
+#################################### Alerting ############################
+[alerting]
+# Disable alerting engine & UI features
+;enabled = true
+# Makes it possible to turn off alert rule execution but alerting UI is visible
+;execute_alerts = true
+
+# Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
+;error_or_timeout = alerting
+
+# Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
+;nodata_or_nullvalues = no_data
+
+# Alert notifications can include images, but rendering many images at the same time can overload the server
+# This limit will protect the server from render overloading and make sure notifications are sent out quickly
+;concurrent_render_limit = 5
+
+#################################### Explore #############################
+[explore]
+# Enable the Explore section
+;enabled = true
+
+#################################### Internal Grafana Metrics ##########################
+# Metrics available at HTTP API Url /metrics
+[metrics]
+# Disable / Enable internal metrics
+;enabled           = true
+
+# Publish interval
+;interval_seconds  = 10
+
+# Send internal metrics to Graphite
+[metrics.graphite]
+# Enable by setting the address setting (ex localhost:2003)
+;address =
+;prefix = prod.grafana.%(instance_name)s.
+
+#################################### Distributed tracing ############
+[tracing.jaeger]
+# Enable by setting the address sending traces to jaeger (ex localhost:6831)
+;address = localhost:6831
+# Tag that will always be included in when creating new spans. ex (tag1:value1,tag2:value2)
+;always_included_tag = tag1:value1
+# Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+;sampler_type = const
+# jaeger samplerconfig param
+# for "const" sampler, 0 or 1 for always false/true respectively
+# for "probabilistic" sampler, a probability between 0 and 1
+# for "rateLimiting" sampler, the number of spans per second
+# for "remote" sampler, param is the same as for "probabilistic"
+# and indicates the initial sampling rate before the actual one
+# is received from the mothership
+;sampler_param = 1
+
+#################################### Grafana.com integration  ##########################
+# Url used to import dashboards directly from Grafana.com
+[grafana_com]
+;url = https://grafana.com
+
+#################################### External image storage ##########################
+[external_image_storage]
+# Used for uploading images to public servers so they can be included in slack/email messages.
+# you can choose between (s3, webdav, gcs, azure_blob, local)
+;provider =
+
+[external_image_storage.s3]
+;bucket =
+;region =
+;path =
+;access_key =
+;secret_key =
+
+[external_image_storage.webdav]
+;url =
+;public_url =
+;username =
+;password =
+
+[external_image_storage.gcs]
+;key_file =
+;bucket =
+;path =
+
+[external_image_storage.azure_blob]
+;account_name =
+;account_key =
+;container_name =
+
+[external_image_storage.local]
+# does not require any configuration
+
+[rendering]
+# Options to configure external image rendering server like https://github.com/grafana/grafana-image-renderer
+;server_url =
+;callback_url =
+
+[enterprise]
+# Path to a valid Grafana Enterprise license.jwt file
+;license_path =
+
+[panels]
+;enable_alpha = false
+# If set to true Grafana will allow script tags in text panels. Not recommended as it enable XSS vulnerabilities.
+;disable_sanitize_html = false
+

--- a/grafana/provisioning/dashboards/sourcegraph.yml
+++ b/grafana/provisioning/dashboards/sourcegraph.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: "default"
+    orgId: 1
+    folder: ""
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/grafana/provisioning/dashboards/sourcegraph/containers.json
+++ b/grafana/provisioning/dashboards/sourcegraph/containers.json
@@ -1,0 +1,574 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1554776868052,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "6.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "time() - process_start_time_seconds{instance=~\"$container\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Process Uptime [rate-10s]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max by (instance)(container:process_cpu_seconds_total:sum{instance=~\"$container\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Container CPU [all cores]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{instance=~\"$container\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory Usage [RSS]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "process_open_fds{instance=~\"$container\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Open File Descriptors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "process_virtual_memory_bytes{instance=~\"$container\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory Usage [VSZ]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": ["$__all"]
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(process_start_time_seconds, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "container",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "searcher-0:6060",
+            "value": "searcher-0:6060"
+          },
+          {
+            "selected": false,
+            "text": "searcher-1:6060",
+            "value": "searcher-1:6060"
+          },
+          {
+            "selected": false,
+            "text": "repo-updater:6060",
+            "value": "repo-updater:6060"
+          },
+          {
+            "selected": false,
+            "text": "gitserver-0:6060",
+            "value": "gitserver-0:6060"
+          },
+          {
+            "selected": false,
+            "text": "localhost:9090",
+            "value": "localhost:9090"
+          },
+          {
+            "selected": false,
+            "text": "sourcegraph-frontend:6060",
+            "value": "sourcegraph-frontend:6060"
+          },
+          {
+            "selected": false,
+            "text": "searcher-2:6060",
+            "value": "searcher-2:6060"
+          },
+          {
+            "selected": false,
+            "text": "query-runner:6060",
+            "value": "query-runner:6060"
+          },
+          {
+            "selected": false,
+            "text": "management-console:6060",
+            "value": "management-console:6060"
+          },
+          {
+            "selected": false,
+            "text": "symbols-0:6060",
+            "value": "symbols-0:6060"
+          },
+          {
+            "selected": false,
+            "text": "github-proxy:6060",
+            "value": "github-proxy:6060"
+          },
+          {
+            "selected": false,
+            "text": "docker.for.mac.host.internal:9323",
+            "value": "docker.for.mac.host.internal:9323"
+          },
+          {
+            "selected": false,
+            "text": "sourcegraph-frontend-internal:6060",
+            "value": "sourcegraph-frontend-internal:6060"
+          }
+        ],
+        "query": "label_values(process_start_time_seconds, instance)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "",
+  "title": "Containers",
+  "uid": "EnHi1iRZz",
+  "version": 3
+}

--- a/grafana/provisioning/dashboards/sourcegraph/gitserver.json
+++ b/grafana/provisioning/dashboards/sourcegraph/gitserver.json
@@ -1,0 +1,604 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1554776827076,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile($percentile, sum(rate(src_gitserver_exec_duration_seconds_bucket{cmd=~\"$command\", instance=~\"$gitserver\"}[10m])) by (le, cmd))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{cmd}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "P$percentile by Command [rate-10m]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(src_gitserver_exec_duration_seconds_count{status=~\"[0-9]+\",cmd=~\"$command\",instance=~\"$gitserver\"}[10m])) by (cmd)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{cmd}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "QPS by Command [rate-10m]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "min(src_gitserver_disk_space_available{instance=~\"$gitserver\"}) BY (instance) / 1000 / 1000 / 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk Space Remaining",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "gbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (instance)(src_gitserver_exec_running{instance=~\"$gitserver\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Running Commands",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (status, cmd)(rate(src_gitserver_exec_duration_seconds_count{instance=~\"$gitserver\"}[10m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{cmd}}: {{status}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "QPS by Exit Status Code",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": ["$__all"]
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(src_gitserver_exec_duration_seconds_bucket, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "gitserver",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "gitserver-0:6060",
+            "value": "gitserver-0:6060"
+          }
+        ],
+        "query": "label_values(src_gitserver_exec_duration_seconds_bucket, instance)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": ".90",
+          "value": ".90"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "percentile",
+        "options": [
+          {
+            "selected": true,
+            "text": ".90",
+            "value": ".90"
+          },
+          {
+            "selected": false,
+            "text": ".95",
+            "value": ".95"
+          },
+          {
+            "selected": false,
+            "text": ".98",
+            "value": ".98"
+          },
+          {
+            "selected": false,
+            "text": ".99",
+            "value": ".99"
+          }
+        ],
+        "query": ".90, .95, .98, .99",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": ["$__all"]
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(src_gitserver_exec_duration_seconds_bucket, cmd)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "command",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "ls-tree",
+            "value": "ls-tree"
+          },
+          {
+            "selected": false,
+            "text": "rev-parse",
+            "value": "rev-parse"
+          },
+          {
+            "selected": false,
+            "text": "archive",
+            "value": "archive"
+          },
+          {
+            "selected": false,
+            "text": "show",
+            "value": "show"
+          },
+          {
+            "selected": false,
+            "text": "log",
+            "value": "log"
+          }
+        ],
+        "query": "label_values(src_gitserver_exec_duration_seconds_bucket, cmd)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "",
+  "title": "Gitserver",
+  "uid": "_r6vamgWk",
+  "version": 4
+}

--- a/grafana/provisioning/dashboards/sourcegraph/http.json
+++ b/grafana/provisioning/dashboards/sourcegraph/http.json
@@ -1,0 +1,441 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1554767384563,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(label_replace(job:src_http_request_count:rate5m, \"c\", \"${1}00s\", \"code\", \"([0-9]).*\")) by (c)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{c}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "QPS by Status Code [rate-5m]",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(route:src_http_request_count:rate5m{route=~\"(xlang|graphql|page.def.landing|page.home|repo.resolve-rev|repo.create|repo.shield|lsp)\"}) by (route)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "QPS by Route [rate-5m]",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile($percentile, route:src_http_request_duration_seconds_bucket:rate5m)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "P$percentile Request Duration [rate-5m]",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "logBase": 1,
+          "max": "10",
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile($percentile, sum(route:src_http_request_duration_seconds_bucket:rate5m) by (le, route))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "P$percentile Overall Route Duration [rate-5m]",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": 3,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": ".90",
+          "value": ".90"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "percentile",
+        "options": [
+          {
+            "selected": true,
+            "text": ".90",
+            "value": ".90"
+          },
+          {
+            "selected": false,
+            "text": ".95",
+            "value": ".95"
+          },
+          {
+            "selected": false,
+            "text": ".98",
+            "value": ".98"
+          },
+          {
+            "selected": false,
+            "text": ".99",
+            "value": ".99"
+          }
+        ],
+        "query": ".90, .95, .98, .99",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "utc",
+  "title": "HTTP",
+  "uid": "000000001",
+  "version": 5
+}

--- a/grafana/provisioning/dashboards/sourcegraph/overview.json
+++ b/grafana/provisioning/dashboards/sourcegraph/overview.json
@@ -1,0 +1,446 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1554767551181,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": ["overview"],
+      "targetBlank": true,
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(label_replace(job:src_http_request_count:rate5m, \"c\", \"${1}00s\", \"code\", \"([0-9]).*\")) by (c)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{c}}",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "QPS by Status Code [rate-5m]",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile($percentile, route:src_http_request_duration_seconds_bucket:rate30m)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "P$percentile Request Duration [rate-30m]",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory Usage [RSS]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max by (instance)(container:process_cpu_seconds_total:sum)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Container CPU [all cores]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": ".90",
+          "value": ".90"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "percentile",
+        "options": [
+          {
+            "selected": true,
+            "text": ".90",
+            "value": ".90"
+          },
+          {
+            "selected": false,
+            "text": ".95",
+            "value": ".95"
+          },
+          {
+            "selected": false,
+            "text": ".98",
+            "value": ".98"
+          },
+          {
+            "selected": false,
+            "text": ".99",
+            "value": ".99"
+          }
+        ],
+        "query": ".90, .95, .98, .99",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "utc",
+  "title": "Overview",
+  "uid": "000000025",
+  "version": 7
+}

--- a/grafana/provisioning/dashboards/sourcegraph/searcher.json
+++ b/grafana/provisioning/dashboards/sourcegraph/searcher.json
@@ -1,0 +1,869 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1554776781222,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "interval": "",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "searcher_service_running{instance=~\"$searcher\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Running Requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "searcher_service_request_total{instance=~\"$searcher\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{code}} ({{instance}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Requests Served by Status Code",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "searcher_errors:rate10m{instance=~\"$searcher\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Errors [rate-10m]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "searcher_requests:rate10m{instance=~\"$searcher\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Requests [rate-10m]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 13,
+      "title": "Archive Cache",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 15,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "searcher_store_fetch_failed{instance=~\"$searcher\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Archive Cache Failed Fetches",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "searcher_store_fetch_queue_size{instance=~\"$searcher\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Archive Cache Fetch Queue Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "searcher_store_cache_size_bytes{instance=~\"$searcher\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Archive Cache Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "searcher_store_evictions{instance=~\"$searcher\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Archive Cache Evictions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "searcher_store_fetching{instance=~\"$searcher\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Archive Cache Running Fetches",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": ["$__all"]
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(searcher_service_running, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "searcher",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "searcher-0:6060",
+            "value": "searcher-0:6060"
+          },
+          {
+            "selected": false,
+            "text": "searcher-1:6060",
+            "value": "searcher-1:6060"
+          },
+          {
+            "selected": false,
+            "text": "searcher-2:6060",
+            "value": "searcher-2:6060"
+          }
+        ],
+        "query": "label_values(searcher_service_running, instance)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "",
+  "title": "Searcher",
+  "uid": "0ZBSEmRWk",
+  "version": 3
+}

--- a/init-jaeger-cassandra-schema.sh
+++ b/init-jaeger-cassandra-schema.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# Description: Initializes Jaeger's Cassandra database. Only needs to run once.
+# Does not run persistently (exits after doing its work).
+#
+docker run --detach \
+    --name=jaeger-cassandra-schema \
+    --network=sourcegraph \
+    -e CQLSH_HOST='jaeger-cassandra' \
+    -e DATACENTER='sourcegraph' \
+    -e KEYSPACE='jaeger_v1_sourcegraph' \
+    -e MODE='prod' \
+    jaegertracing/jaeger-cassandra-schema@sha256:ba0ffb1953c76705539360c2f83eafe32b977529c3399d1abeb69c94f29c45d0
+
+echo "Deployed jaeger-cassandra-schema initializer"

--- a/metrics-and-tracing.md
+++ b/metrics-and-tracing.md
@@ -1,0 +1,74 @@
+# deploy-sourcegraph-docker metrics
+
+This deployment mode of Sourcegraph features metrics that are a staple in other cluster Sourcegraph deployments:
+
+- [Jaeger tracing](https://www.jaegertracing.io/), for getting exact details on specific requests.
+- [Grafana](https://grafana.com/) and [Prometheus](https://prometheus.io), for dashboards with nice high-level insight into Sourcegraph ([it can also send alerts](http://docs.grafana.org/alerting/rules/), although we are not aware of anyone using it for that yet).
+
+### A brief note about security
+
+It is your responsibility to ensure that Jaeger, Grafana, and Prometheus are only accessible by admins. In specific, you will want a way for admins to access:
+
+- jaeger-query HTTP port 16686.
+- grafana HTTP port 3000.
+- prometheus HTTP port 9090.
+
+This is due to the fact that these services (in particular, Jaeger) record details about HTTP queries, which may contain sensitive information.
+
+# Jaeger tracing
+
+Jaeger tracing allows you to grab a detailed trace for any HTTP request that goes through Sourcegraph. It can provide us critical information like:
+
+- What operations occurred behind the scenes?
+- How long did those operations take?
+- What errors occurred while performing those operations?
+- etc.
+
+![image](https://user-images.githubusercontent.com/3173176/55772329-91152680-5a40-11e9-82ea-e29def753266.png)
+
+To use Jaeger after running `deploy.sh`:
+
+1. Visit jaeger-query in a browser (e.g. at http://localhost:16686) and confirm there are no errors displayed on the home page (you should just see a stern-looking Gopher with a hat).
+   - If there are errors, you may need to wait a few minutes for Jaeger's Cassandra database to initialize if it is the first time you are running this. It can take around 5 minutes.
+   - Consult `docker ps | grep jaeger` until all containers have started.
+2. In the Sourcegraph management console, set `"useJaeger": true`, then restart all Sourcegraph services. This will cause Sourcegraph's services to begin sending tracing information to Jaeger. It is safe (and highly recommended) to run this in production.
+
+### Acquiring traces
+
+Every HTTP response sent by Sourcegraph will have a header like `X-Trace: 5023c9288d9d4797`. This trace ID can be put into Jaeger to view the trace.
+
+# Grafana and Prometheus
+
+Grafana queries Prometheus to provide dashboards with high-level insight into Sourcegraph. (It can also provide alerting on specific metrics, if desired):
+
+![image](https://user-images.githubusercontent.com/3173176/55769416-9751d580-5a35-11e9-892d-198b02bb3663.png)
+
+To use Grafana and Prometheus after running `deploy.sh`:
+
+1. If you have multiple replicas of searcher/gitserver/etc, open `prometheus/prometheus_targets.yml` in an editor and duplicate lines as needed so that Prometheus knows to scrape those services for metrics. Save the file, then `docker restart prometheus` to apply the changes.
+1. Visit grafana in a browser (e.g. at http://localhost:3000) and sign in using the default credentials `admin` > `admin`.
+1. Add Prometheus as a data source: **Gear icon** > **Data sources** > **Add data source** > **Prometheus** > enter the Prometheus URL (e.g. `http://localhost:9090` on Linux or `http://docker.for.mac.localhost:9090` on Mac).
+1. You can now visit any dashboards via: **Dashboard icon** > **Home** > **Home dropdown in top-left** > **<the dashboard>**.
+
+### Sourcegraph standard dashboards
+
+The deployment comes with a set of standard dashboards for monitoring Sourcegraph:
+
+- **Overview** - high level overview of how Sourcegraph is performing
+- **Containers** - insight into Docker containers themselves (memory, CPU, open file descriptors, etc). Requires additional configuratoin, see below.
+- **HTTP** - insight into end-user HTTP requests (i.e. excluding interservice communication)
+- **Searcher** - detailed insight into the searcher service
+- **Gitserver** - detailed insight into the gitserver service
+
+The JSON for these dashboards is located in the `grafana/provisioning/sourcegraph` directory. It is intended that thes are maintained by Sourcegraph and will recieve regular updates (you will get updates on redeploy, no need to do anything special).
+
+If there are specific dashboards or metrics you'd like to see, please [file an issue](https://github.com/sourcegraph/sourcegraph/issues) to let us know!
+
+### Container metrics
+
+The `Containers` dashboard metrics come from Docker itself. In order to expose these metrics to Prometheus, you will need to:
+
+1. Flip a bit in the Docker config to expose its Prometheus metrics exporter: https://docs.docker.com/config/thirdparty/prometheus/#configure-docker
+2. Uncomment the relevant `job_name: docker` line at the end of `prometheus/prometheus_targets.yml` for your OS.
+3. `docker restart prometheus` to make the changes take effect.
+4. To confirm the above worked, you can run a Prometheus query [like this](http://localhost:9090/graph?g0.range_input=1h&g0.expr=process_resident_memory_bytes&g0.tab=0) or visit the `Containers` dashboard in Grafana.

--- a/metrics-and-tracing.md
+++ b/metrics-and-tracing.md
@@ -45,9 +45,10 @@ Grafana queries Prometheus to provide dashboards with high-level insight into So
 
 To use Grafana and Prometheus after running `deploy.sh`:
 
+1. If running on a Linux host, you may need to `sudo chown -R 472:472 ~/sourcegraph-docker/grafana-disk` in order to correct the permissions of the Grafana disk so that it starts.
 1. If you have multiple replicas of searcher/gitserver/etc, open `prometheus/prometheus_targets.yml` in an editor and duplicate lines as needed so that Prometheus knows to scrape those services for metrics. Save the file, then `docker restart prometheus` to apply the changes.
 1. Visit grafana in a browser (e.g. at http://localhost:3000) and sign in using the default credentials `admin` > `admin`.
-1. Add Prometheus as a data source: **Gear icon** > **Data sources** > **Add data source** > **Prometheus** > enter the Prometheus URL (e.g. `http://localhost:9090` on Linux or `http://docker.for.mac.localhost:9090` on Mac).
+1. Add Prometheus as a data source: **Gear icon** > **Data sources** > **Add data source** > **Prometheus** > enter the Prometheus URL `http://prometheus:9090`.
 1. You can now visit any dashboards via: **Dashboard icon** > **Home** > **Home dropdown in top-left** > **<the dashboard>**.
 
 ### Sourcegraph standard dashboards

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -1,0 +1,7 @@
+# Prometheus configuration
+
+This directory contains configuration for the [Prometheus](https://prometheus.io/) metrics deployment.
+
+This directory is mounted into the `prometheus` container. After making your changes to this directory,
+simply `docker restart prometheus` for your changes to take effect (depending on your change, Prometheus
+may respond to it as soon as you save the file).

--- a/prometheus/docker.rules
+++ b/prometheus/docker.rules
@@ -1,0 +1,6 @@
+# Docker container monitoring rules
+
+container:process_cpu_seconds_total:ratio_rate5m = sum by (instance) (rate(process_cpu_seconds_total[5m])) / engine_daemon_engine_cpus_cpus
+container:process_cpu_seconds_total:sum = sum by (instance) (irate(process_cpu_seconds_total[1m]))
+container:process_resident_memory_bytes:max = max by (instance) (process_resident_memory_bytes)
+container:process_virtual_memory_bytes:max = max by (instance) (process_virtual_memory_bytes)

--- a/prometheus/frontend.rules
+++ b/prometheus/frontend.rules
@@ -1,0 +1,28 @@
+# Frontend service rules
+
+# Duration (5m)
+task:src_http_request_duration_seconds_bucket:rate5m = rate(src_http_request_duration_seconds_bucket{instance=~"sourcegraph-.*"}[5m])
+route:src_http_request_duration_seconds_bucket:rate5m = sum by (route, ns, le)(task:src_http_request_duration_seconds_bucket:rate5m)
+job:src_http_request_duration_seconds_bucket:rate5m = sum by (ns, le)(task:src_http_request_duration_seconds_bucket:rate5m)
+prod:src_http_request_duration_seconds_bucket:rate5m = sum by (le)(task:src_http_request_duration_seconds_bucket:rate5m)
+
+# Counts (5m)
+task:src_http_request_count:rate5m = rate(src_http_request_duration_seconds_count{instance=~"sourcegraph-.*"}[5m])
+route:src_http_request_count:rate5m = sum by (route, code, ns)(task:src_http_request_count:rate5m)
+job:src_http_request_count:rate5m = sum by (code, ns)(task:src_http_request_count:rate5m)
+prod:src_http_request_count:rate5m = sum by (code)(task:src_http_request_count:rate5m)
+
+# Duration (30m)
+task:src_http_request_duration_seconds_bucket:rate30m = rate(src_http_request_duration_seconds_bucket{instance=~"sourcegraph-.*"}[30m])
+route:src_http_request_duration_seconds_bucket:rate30m = sum by (route, ns, le)(task:src_http_request_duration_seconds_bucket:rate30m)
+job:src_http_request_duration_seconds_bucket:rate30m = sum by (ns, le)(task:src_http_request_duration_seconds_bucket:rate30m)
+prod:src_http_request_duration_seconds_bucket:rate30m = sum by (le)(task:src_http_request_duration_seconds_bucket:rate30m)
+
+# Counts (30m)
+task:src_http_request_count:rate30m = rate(src_http_request_duration_seconds_count{instance=~"sourcegraph-.*"}[30m])
+route:src_http_request_count:rate30m = sum by (route, code, ns)(task:src_http_request_count:rate30m)
+job:src_http_request_count:rate30m = sum by (code, ns)(task:src_http_request_count:rate30m)
+prod:src_http_request_count:rate30m = sum by (code)(task:src_http_request_count:rate30m)
+
+# Perf targets are over a day
+prod:src_http_request_duration_seconds_bucket:rate1d = sum by (route, le)(rate(src_http_request_duration_seconds_bucket{instance=~"sourcegraph-.*"}[1d]))

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,46 @@
+# Prometheus global config
+global:
+  scrape_interval: 30s # Scrape services for updated metrics every 30s. Default is 1m.
+  evaluation_interval: 30s # Evaluate rules every 30s. Default is 1m.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # deploy-sourcegraph-docker does not yet use prometheus alerts
+          # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  - "docker.rules"
+  - "frontend.rules"
+  - "searcher.rules"
+  - "service.rules"
+  - "symbols.rules"
+
+# A scrape configuration containing exactly one endpoint to scrape for metrics:
+scrape_configs:
+  # Scrape prometheus itself for metrics.
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # Scrape Docker for metrics.
+  # You will need to configure docker for this to work: https://docs.docker.com/config/thirdparty/prometheus/#configure-docker
+  - job_name: "docker"
+    static_configs:
+      # For Linux, use this line:
+      #- targets: ["localhost:9323"]
+      #
+      # For Mac, use this line:
+      #- targets: ["docker.for.mac.host.internal:9323"]
+      #
+      # For Windows, use this line:
+      #- targets: ["docker.for.win.localhost:9090"]
+
+  - job_name: "node"
+    file_sd_configs:
+      - files:
+          - "/etc/prometheus/prometheus_targets.yml"

--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -1,0 +1,20 @@
+---
+- labels:
+    job: node
+  targets:
+    # Uncomment these if you want to monitor PostgreSQL / Redis via Prometheus.
+    #- pgsql:9187
+    #- redis-cache:9121
+    #- redis-store:9121
+    - sourcegraph-frontend:6060
+    - sourcegraph-frontend-internal:6060
+    - github-proxy:6060
+    - management-console:6060
+    - query-runner:6060
+    - repo-updater:6060
+    # Add new entries here for every searcher/symbol/gitserver replica.
+    - gitserver-0:6060
+    - searcher-0:6060
+    - searcher-1:6060
+    - searcher-2:6060
+    - symbols-0:6060

--- a/prometheus/searcher.rules
+++ b/prometheus/searcher.rules
@@ -1,0 +1,4 @@
+# Searcher service rules
+searcher_requests:rate10m = sum by (instance)(rate(searcher_service_request_total[10m]))
+searcher_errors:rate10m   = sum by (instance)(rate(searcher_service_request_total{code!="200",code!="canceled"}[10m]))
+searcher_errors:ratio10m  = sum(searcher_errors:rate10m) / sum(searcher_requests:rate10m)

--- a/prometheus/service.rules
+++ b/prometheus/service.rules
@@ -1,0 +1,6 @@
+# Rules for monitoring Sourcegraph service themselves (not their metrics).
+
+# Measure uptime of services's docker containers
+instance:up:sum   = sum by (instance)(up)
+instance:up:count = count by (instance)(up)
+instance:up:ratio = instance:up:sum / on (instance) instance:up:count

--- a/prometheus/symbols.rules
+++ b/prometheus/symbols.rules
@@ -1,0 +1,4 @@
+# Searcher service rules
+symbols_requests:rate10m = sum by (instance)(rate(symbols_service_request_total[10m]))
+symbols_errors:rate10m   = sum by (instance)(rate(symbols_service_request_total{code!="200",code!="canceled"}[10m]))
+symbols_errors:ratio10m  = sum(symbols_errors:rate10m) / sum(symbols_requests:rate10m)

--- a/teardown.sh
+++ b/teardown.sh
@@ -12,6 +12,7 @@ docker rm -f jaeger-query &> /dev/null || true
 docker rm -f jaeger-cassandra-schema &> /dev/null || true
 docker rm -f management-console &> /dev/null || true
 docker rm -f pgsql &> /dev/null || true
+docker rm -f prometheus &> /dev/null || true
 docker rm -f query-runner &> /dev/null || true
 docker rm -f redis-cache &> /dev/null || true
 docker rm -f redis-store &> /dev/null || true

--- a/teardown.sh
+++ b/teardown.sh
@@ -5,6 +5,7 @@ docker rm -f sourcegraph-frontend-internal &> /dev/null || true
 docker rm -f sourcegraph-frontend &> /dev/null || true
 docker rm -f github-proxy &> /dev/null || true
 docker rm -f gitserver-0 &> /dev/null || true
+docker rm -f grafana &> /dev/null || true
 docker rm -f jaeger-agent &> /dev/null || true
 docker rm -f jaeger-cassandra &> /dev/null || true
 docker rm -f jaeger-collector &> /dev/null || true

--- a/teardown.sh
+++ b/teardown.sh
@@ -5,6 +5,11 @@ docker rm -f sourcegraph-frontend-internal &> /dev/null || true
 docker rm -f sourcegraph-frontend &> /dev/null || true
 docker rm -f github-proxy &> /dev/null || true
 docker rm -f gitserver-0 &> /dev/null || true
+docker rm -f jaeger-agent &> /dev/null || true
+docker rm -f jaeger-cassandra &> /dev/null || true
+docker rm -f jaeger-collector &> /dev/null || true
+docker rm -f jaeger-query &> /dev/null || true
+docker rm -f jaeger-cassandra-schema &> /dev/null || true
 docker rm -f management-console &> /dev/null || true
 docker rm -f pgsql &> /dev/null || true
 docker rm -f query-runner &> /dev/null || true


### PR DESCRIPTION
This PR adds built-in support for Jaeger tracing and Grafana/Prometheus metrics. For further details, please refer to the `metrics-and-tracing.md` document in this PR.

Helps sourcegraph/sourcegraph#3175
Fixes #3 