### PR TITLE
all: add proper resource constraints

### DIFF
--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Serves the internal Sourcegraph frontend API.
 #
-# CPU: 2
-# Memory: 4GB
 # Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=sourcegraph-frontend-internal \
     --network=sourcegraph \
     --restart=always \
+    --cpus=2 \
+    --memory=4g \
     -e PGHOST=pgsql \
     -e SRC_GIT_SERVERS=gitserver-0:3178 \
     -e SRC_SYNTECT_SERVER=http://syntect-server:9238 \

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Serves the frontend of Sourcegraph via HTTP(S).
 #
-# CPU: 2
-# Memory: 4GB
 # Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: HTTP GET http://sourcegraph-frontend:3080/healthz
@@ -15,6 +13,8 @@ docker run --detach \
     --name=sourcegraph-frontend \
     --network=sourcegraph \
     --restart=always \
+    --cpus=2 \
+    --memory=4g \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -e PGHOST=pgsql \
     -e SRC_GIT_SERVERS=gitserver-0:3178 \

--- a/deploy-github-proxy.sh
+++ b/deploy-github-proxy.sh
@@ -15,6 +15,8 @@ docker run --detach \
     --name=github-proxy \
     --network=sourcegraph \
     --restart=always \
+    --cpus=1 \
+    --memory=1g \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     sourcegraph/github-proxy:3.2.1

--- a/deploy-gitserver.sh
+++ b/deploy-gitserver.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Stores clones of repositories to perform Git operations.
 #
-# CPU: 4
-# Memory: 8GB
 # Disk: 200GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=gitserver-0 \
     --network=sourcegraph \
     --restart=always \
+    --cpus=4 \
+    --memory=8g \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/gitserver-0-disk:/data/repos \

--- a/deploy-grafana.sh
+++ b/deploy-grafana.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Dashboards and graphs for Prometheus metrics.
 #
-# CPU: 1
-# Memory: 1GB
 # Disk: 100GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=grafana \
     --network=sourcegraph \
     --restart=always \
+    --cpus=1 \
+    --memory=1g \
     -p 0.0.0.0:3000:3000 \
     -v ~/sourcegraph-docker/grafana-disk:/var/lib/grafana \
     -v $(pwd)/grafana:/etc/grafana \

--- a/deploy-jaeger-agent.sh
+++ b/deploy-jaeger-agent.sh
@@ -4,8 +4,6 @@ set -e
 # Description: Jaeger agent which is local to the host machine (containers on
 # the machine send trace information to it and it relays to the collector).
 #
-# CPU: 1
-# Memory: 1GB
 # Disk: none
 # Network: 100mbps
 # Liveness probe: n/a
@@ -16,5 +14,7 @@ docker run --detach \
     --name=jaeger-agent \
     --network=sourcegraph \
     --restart=always \
+    --cpus=1 \
+    --memory=1g \
     -e COLLECTOR_HOST_PORT='jaeger-collector:14267' \
     jaegertracing/jaeger-agent@sha256:7ad33c19fd66307f2a3c07c95eb07c335ddce1b487f6b6128faa75d042c496cb

--- a/deploy-jaeger-cassandra.sh
+++ b/deploy-jaeger-cassandra.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Jaeger's Cassandra database for storing traces.
 #
-# CPU: 4
-# Memory: 8GB
 # Disk: 128GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=jaeger-cassandra \
     --network=sourcegraph \
     --restart=always \
+    --cpus=4 \
+    --memory=8g \
     -e HEAP_NEWSIZE='1G' \
     -e MAX_HEAP_SIZE='6G' \
     -e CASSANDRA_DC='sourcegraph' \

--- a/deploy-jaeger-collector.sh
+++ b/deploy-jaeger-collector.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Receives traces from Jaeger agents.
 #
-# CPU: 1
-# Memory: 1GB
 # Disk: none
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=jaeger-collector \
     --network=sourcegraph \
     --restart=always \
+    --cpus=1 \
+    --memory=1g \
     -e SPAN_STORAGE_TYPE=cassandra \
     -e CASSANDRA_SERVERS=jaeger-cassandra \
     -e CASSANDRA_KEYSPACE=jaeger_v1_sourcegraph \

--- a/deploy-jaeger-query.sh
+++ b/deploy-jaeger-query.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Jaeger frontend for querying traces.
 #
-# CPU: 1
-# Memory: 1GB
 # Disk: none
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=jaeger-query \
     --network=sourcegraph \
     --restart=always \
+    --cpus=1 \
+    --memory=1g \
     -p 0.0.0.0:16686:16686 \
     -e SPAN_STORAGE_TYPE=cassandra \
     -e CASSANDRA_SERVERS=jaeger-cassandra \

--- a/deploy-management-console.sh
+++ b/deploy-management-console.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Serves the frontend of Sourcegraph via HTTP(S).
 #
-# CPU: 1
-# Memory: 512MB
 # Disk: 1GB / persistent (can be discarded, only contains self-signed TLS cert)
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=management-console \
     --network=sourcegraph \
     --restart=always \
+    --cpus=1 \
+    --memory=512m \
     -v ~/sourcegraph-docker/management-console-disk:/etc/sourcegraph \
     -e PGHOST=pgsql \
     -p 0.0.0.0:2633:2633 \

--- a/deploy-pgsql.sh
+++ b/deploy-pgsql.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: PostgreSQL database for various data.
 #
-# CPU: 2
-# Memory: 1GB
 # Disk: 128GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: 5432/TCP
@@ -15,6 +13,8 @@ docker run --detach \
     --name=pgsql \
     --network=sourcegraph \
     --restart=always \
+    --cpus=2 \
+    --memory=1g \
     -v ~/sourcegraph-docker/pgsql-disk:/data/pgdata \
     sourcegraph/postgres:18-11-26_9.4_a9463ecc@sha256:ca9964a200beb9756704279f82f13caea39eaee8ee9e9e13eba57f2de4952f71
 

--- a/deploy-prometheus.sh
+++ b/deploy-prometheus.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Prometheus collects metrics and aggregates them into graphs.
 #
-# CPU: 4
-# Memory: 8GB
 # Disk: 200GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=prometheus \
     --network=sourcegraph \
     --restart=always \
+    --cpus=4 \
+    --memory=8g \
     -p 0.0.0.0:9090:9090 \
     -v ~/sourcegraph-docker/prometheus-disk:/prometheus-data \
     -v $(pwd)/prometheus:/etc/prometheus \

--- a/deploy-query-runner.sh
+++ b/deploy-query-runner.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Saved search query runner / notification service.
 #
-# CPU: 1
-# Memory: 1GB
 # Disk: 1GB / non-persistent SSD (only for read-only config file)
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=query-runner \
     --network=sourcegraph \
     --restart=always \
+    --cpus=1 \
+    --memory=1g \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     sourcegraph/query-runner:3.2.1

--- a/deploy-redis-cache.sh
+++ b/deploy-redis-cache.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Redis for storing short-lived caches.
 #
-# CPU: 1
-# Memory: 6GB
 # Disk: 128GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: 6379/TCP
@@ -15,6 +13,8 @@ docker run --detach \
     --name=redis-cache \
     --network=sourcegraph \
     --restart=always \
+    --cpus=1 \
+    --memory=6g \
     -v ~/sourcegraph-docker/redis-cache-disk:/redis-data \
     sourcegraph/redis-cache:18-10-28_ba610fdf@sha256:10a4430cb8bb9c0ad2b96eac40882509fb1b11cbd77cffd0900f74a58a4014d2
 

--- a/deploy-redis-store.sh
+++ b/deploy-redis-store.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Redis for storing semi-persistent data like user sessions.
 #
-# CPU: 1
-# Memory: 6GB
 # Disk: 128GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: 6379/TCP
@@ -15,6 +13,8 @@ docker run --detach \
     --name=redis-store \
     --network=sourcegraph \
     --restart=always \
+    --cpus=1 \
+    --memory=6g \
     -v ~/sourcegraph-docker/redis-store-disk:/redis-data \
     sourcegraph/redis-store:18-10-28_e45f6d82@sha256:1fe101e1f04a8e267fda85c342cd3b974ab4a9e47718b864752f14f1da51579c \
 

--- a/deploy-repo-updater.sh
+++ b/deploy-repo-updater.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Handles repository metadata (not Git data) lookups and updates from external code hosts and other similar services.
 #
-# CPU: 1
-# Memory: 512MB
 # Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=repo-updater \
     --network=sourcegraph \
     --restart=always \
+    --cpus=1 \
+    --memory=512m \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \

--- a/deploy-searcher.sh
+++ b/deploy-searcher.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Backend for text search operations.
 #
-# CPU: 2
-# Memory: 2GB
 # Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: HTTP GET http://searcher:3181/healthz
@@ -15,6 +13,8 @@ docker run --detach \
     --name=searcher-0 \
     --network=sourcegraph \
     --restart=always \
+    --cpus=2 \
+    --memory=2g \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/searcher-0-disk:/mnt/cache \

--- a/deploy-symbols.sh
+++ b/deploy-symbols.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Backend for symbols operations.
 #
-# CPU: 2
-# Memory: 2GB
 # Disk: 128GB / non-persistent SSD
 # Network: 100mbps
 # Liveness probe: none
@@ -15,6 +13,8 @@ docker run --detach \
     --name=symbols-0 \
     --network=sourcegraph \
     --restart=always \
+    --cpus=2 \
+    --memory=2g \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
     -v ~/sourcegraph-docker/symbols-0-disk:/mnt/cache \

--- a/deploy-syntect-server.sh
+++ b/deploy-syntect-server.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Backend for syntax highlighting operations.
 #
-# CPU: 2
-# Memory: 512MB
 # Disk: none
 # Network: 100mbps
 # Liveness probe: HTTP GET http://syntect-server:9238/health
@@ -15,6 +13,8 @@ docker run --detach \
     --name=syntect-server \
     --network=sourcegraph \
     --restart=always \
+    --cpus=4 \
+    --memory=512m \
     sourcegraph/syntect_server:056c730@sha256:2f7489ebddfbbe92bef3e72af3840d24f45d387baa0da1edabf06fa732195ae6
 
 echo "Deployed syntect-server service"

--- a/deploy-zoekt-indexserver.sh
+++ b/deploy-zoekt-indexserver.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Backend for indexed text search operations.
 #
-# CPU: 4
-# Memory: 4GB
 # Disk: 200GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: n/a
@@ -15,6 +13,8 @@ docker run --detach \
     --name=zoekt-indexserver \
     --network=sourcegraph \
     --restart=always \
+    --cpus=4 \
+    --memory=4g \
     -e SRC_FRONTEND_INTERNAL=http://sourcegraph-frontend-internal:3090 \
     -v ~/sourcegraph-docker/zoekt-shared-disk:/data/index \
     sourcegraph/zoekt-indexserver:18-10-30_faca01d@sha256:36c1309d935b7faf5ec69277444a6c0eefa510a6eb20deb651cdb7ce3de3913f

--- a/deploy-zoekt-webserver.sh
+++ b/deploy-zoekt-webserver.sh
@@ -3,8 +3,6 @@ set -e
 
 # Description: Backend for indexed text search operations.
 #
-# CPU: 2
-# Memory: 4GB
 # Disk: 200GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: HTTP GET http://zoekt-webserver:6070/healthz
@@ -15,6 +13,8 @@ docker run --detach \
     --name=zoekt-webserver \
     --network=sourcegraph \
     --restart=always \
+    --cpus=2 \
+    --memory=4g \
     -v ~/sourcegraph-docker/zoekt-shared-disk:/data/index \
     sourcegraph/zoekt-webserver:18-10-30_faca01d@sha256:afadb33c9c254256fc41a6cbd372d2eca93140eebc1fee05367fd81059ea7205
 


### PR DESCRIPTION
Prior to this change services could scale up to the # of cores, which was inconsistent with our Kubernetes deployments which enforce this is not possible via the same underlying mechanism (Docker resource constraints). This meant that some services could scale to consume their entire workload quickly, at the detriment of other services.

After this change, we have proper resource constraints in place which ensures this does not occur and system stability is ensured over e.g. responding to one specific query ASAP by using 100% of all cores.

