### PR TITLE
add support for specifying replica counts for cluster deployments

### DIFF
--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+source ./replicas.sh
 
 # Description: Serves the internal Sourcegraph frontend API.
 #
@@ -16,10 +17,10 @@ docker run --detach \
     --cpus=4 \
     --memory=4g \
     -e PGHOST=pgsql \
-    -e SRC_GIT_SERVERS=gitserver-0:3178 \
+    -e SRC_GIT_SERVERS="$(addresses "gitserver-" $NUM_GITSERVER ":3178")" \
     -e SRC_SYNTECT_SERVER=http://syntect-server:9238 \
-    -e SEARCHER_URL=http://searcher-0:3181 \
-    -e SYMBOLS_URL=http://symbols-0:3184 \
+    -e SEARCHER_URL="$(addresses "http://searcher-" $NUM_SEARCHER ":3181")" \
+    -e SYMBOLS_URL="$(addresses "http://symbols-" $NUM_SYMBOLS ":3184")" \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e REPO_UPDATER_URL=http://repo-updater:3182 \
     -e ZOEKT_HOST=zoekt-webserver:6070 \

--- a/deploy-github-proxy.sh
+++ b/deploy-github-proxy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+source ./replicas.sh
 
 # Description: Rate-limiting proxy for the GitHub API.
 #

--- a/deploy-gitserver.sh
+++ b/deploy-gitserver.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+source ./replicas.sh
 
 # Description: Stores clones of repositories to perform Git operations.
 #
@@ -10,14 +11,14 @@ set -e
 # Ports exposed to the public internet: none
 #
 docker run --detach \
-    --name=gitserver-0 \
+    --name=gitserver-$1 \
     --network=sourcegraph \
     --restart=always \
     --cpus=4 \
     --memory=8g \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
-    -v ~/sourcegraph-docker/gitserver-0-disk:/data/repos \
+    -v ~/sourcegraph-docker/gitserver-$1-disk:/data/repos \
     sourcegraph/gitserver:3.2.1
 
-echo "Deployed gitserver service"
+echo "Deployed gitserver $1 service"

--- a/deploy-repo-updater.sh
+++ b/deploy-repo-updater.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+source ./replicas.sh
 
 # Description: Handles repository metadata (not Git data) lookups and updates from external code hosts and other similar services.
 #

--- a/deploy-searcher.sh
+++ b/deploy-searcher.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+source ./replicas.sh
 
 # Description: Backend for text search operations.
 #
@@ -10,14 +11,14 @@ set -e
 # Ports exposed to the public internet: none
 #
 docker run --detach \
-    --name=searcher-0 \
+    --name=searcher-$1 \
     --network=sourcegraph \
     --restart=always \
     --cpus=2 \
     --memory=2g \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
-    -v ~/sourcegraph-docker/searcher-0-disk:/mnt/cache \
+    -v ~/sourcegraph-docker/searcher-$1-disk:/mnt/cache \
     sourcegraph/searcher:3.2.1
 
-echo "Deployed searcher service"
+echo "Deployed searcher $1 service"

--- a/deploy-symbols.sh
+++ b/deploy-symbols.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+source ./replicas.sh
 
 # Description: Backend for symbols operations.
 #
@@ -10,14 +11,14 @@ set -e
 # Ports exposed to the public internet: none
 #
 docker run --detach \
-    --name=symbols-0 \
+    --name=symbols-$1 \
     --network=sourcegraph \
     --restart=always \
     --cpus=2 \
     --memory=2g \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST='jaeger-agent' \
-    -v ~/sourcegraph-docker/symbols-0-disk:/mnt/cache \
+    -v ~/sourcegraph-docker/symbols-$1-disk:/mnt/cache \
     sourcegraph/symbols:3.2.1
 
-echo "Deployed symbols service"
+echo "Deployed symbols $1 service"

--- a/deploy-zoekt-indexserver.sh
+++ b/deploy-zoekt-indexserver.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+source ./replicas.sh
 
 # Description: Backend for indexed text search operations.
 #

--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -6,15 +6,13 @@
     #- pgsql:9187
     #- redis-cache:9121
     #- redis-store:9121
-    - sourcegraph-frontend:6060
     - sourcegraph-frontend-internal:6060
     - github-proxy:6060
     - management-console:6060
     - query-runner:6060
     - repo-updater:6060
     # Add new entries here for every searcher/symbol/gitserver replica.
+    - sourcegraph-frontend-0:6060
     - gitserver-0:6060
     - searcher-0:6060
-    - searcher-1:6060
-    - searcher-2:6060
     - symbols-0:6060

--- a/replicas.sh
+++ b/replicas.sh
@@ -1,0 +1,7 @@
+# Here you can specify the number of service replicas to deploy.
+NUM_GITSERVER=1
+NUM_SEARCHER=1
+NUM_SYMBOLS=1
+NUM_FRONTEND=1
+
+addresses() { for i in $(seq 0 $(($2 - 1))); do echo -n "$1$i$3 "; done }

--- a/teardown.sh
+++ b/teardown.sh
@@ -1,27 +1,29 @@
 #!/usr/bin/env bash
 set -e
+source ./replicas.sh
 
-docker rm -f sourcegraph-frontend-internal &> /dev/null || true
-docker rm -f sourcegraph-frontend &> /dev/null || true
-docker rm -f github-proxy &> /dev/null || true
-docker rm -f gitserver-0 &> /dev/null || true
+docker rm -f sourcegraph-frontend-internal &> /dev/null || true &
+docker rm -f $(addresses "sourcegraph-frontend-" $NUM_FRONTEND "") &> /dev/null || true &
+docker rm -f github-proxy &> /dev/null || true &
+docker rm -f $(addresses "gitserver-" $NUM_GITSERVER "") &> /dev/null || true &
 docker rm -f grafana &> /dev/null || true
 docker rm -f jaeger-agent &> /dev/null || true
 docker rm -f jaeger-cassandra &> /dev/null || true
 docker rm -f jaeger-collector &> /dev/null || true
 docker rm -f jaeger-query &> /dev/null || true
 docker rm -f jaeger-cassandra-schema &> /dev/null || true
-docker rm -f management-console &> /dev/null || true
-docker rm -f pgsql &> /dev/null || true
+docker rm -f management-console &> /dev/null || true &
+docker rm -f pgsql &> /dev/null || true &
 docker rm -f prometheus &> /dev/null || true
-docker rm -f query-runner &> /dev/null || true
-docker rm -f redis-cache &> /dev/null || true
-docker rm -f redis-store &> /dev/null || true
-docker rm -f repo-updater &> /dev/null || true
-docker rm -f searcher-0 &> /dev/null || true
-docker rm -f symbols-0 &> /dev/null || true
-docker rm -f syntect-server &> /dev/null || true
-docker rm -f zoekt-indexserver &> /dev/null || true
-docker rm -f zoekt-webserver &> /dev/null || true
+docker rm -f query-runner &> /dev/null || true &
+docker rm -f redis-cache &> /dev/null || true &
+docker rm -f redis-store &> /dev/null || true &
+docker rm -f repo-updater &> /dev/null || true &
+docker rm -f $(addresses "searcher-" $NUM_SEARCHER "") &> /dev/null || true &
+docker rm -f $(addresses "symbols-" $NUM_SYMBOLS "") &> /dev/null || true &
+docker rm -f syntect-server &> /dev/null || true &
+docker rm -f zoekt-indexserver &> /dev/null || true &
+docker rm -f zoekt-webserver &> /dev/null || true &
 
-docker network rm sourcegraph &> /dev/null || true
+docker network rm sourcegraph &> /dev/null || true &
+wait


### PR DESCRIPTION
After this change, in order to deploy multiple `gitserver`, `searcher`, `symbols`, or `frontend` replicas you can simply modify the `replicas.sh` file and then run `./deploy.sh`.

Multiple frontend containers will be exposed on consecutive ports (3080, 3081, 3082, and so on.)

For an example of how a complete configuration for multiple replicas looks like, see https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/31/files