### PR TITLE
Update zoekt for 3.7 release

### DIFF
--- a/deploy-zoekt-indexserver.sh
+++ b/deploy-zoekt-indexserver.sh
@@ -19,6 +19,6 @@ docker run --detach \
     -e GOMAXPROCS=4 \
     -e SRC_FRONTEND_INTERNAL=http://sourcegraph-frontend-internal:3090 \
     -v ~/sourcegraph-docker/zoekt-shared-disk:/data/index \
-    sourcegraph/zoekt-indexserver:19-08-14_75b5f54@sha256:fd84a483c72943f016f70de74365be6673a0e85de54a98e86d300736d939e9e1
+    sourcegraph/zoekt-indexserver:2019.08.19-014a202@sha256:3e3ff3723c96afd479177f51f25d0b4e6081281db3e6329aa3ef0a6db1759d99
 
 echo "Deployed zoekt-indexserver service"

--- a/deploy-zoekt-webserver.sh
+++ b/deploy-zoekt-webserver.sh
@@ -17,6 +17,6 @@ docker run --detach \
     --memory=80g \
     -e GOMAXPROCS=8 \
     -v ~/sourcegraph-docker/zoekt-shared-disk:/data/index \
-    sourcegraph/zoekt-webserver:19-08-14_75b5f54@sha256:aa1265e39823a02d9a58f0b72c696bc0fd80320d2036e63be28a95892859e0fd
+    sourcegraph/zoekt-webserver:2019.08.19-014a202@sha256:1f1420ed341c3f7bc3041cd46c4bf1eba97b830aeffce9640472daccb2621788
 
 echo "Deployed zoekt-webserver service"


### PR DESCRIPTION
This includes the final changes we want to ship for zoekt in 3.7. It requires
frontend to also be on the latest version of 3.7 since we made a minor change
to the zoekt API.

Part of https://github.com/sourcegraph/sourcegraph/pull/5290