### PR TITLE
Cleanup some monitoring changes

### DIFF
--- a/deploy-grafana.sh
+++ b/deploy-grafana.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -e
 
 # Description: Dashboards and graphs for Prometheus metrics.

--- a/deploy-prometheus.sh
+++ b/deploy-prometheus.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -e
 
 # Description: Prometheus collects metrics and aggregates them into graphs.

--- a/deploy-prometheus.sh
+++ b/deploy-prometheus.sh
@@ -17,6 +17,6 @@ docker run --detach \
     --cpus=4 \
     --memory=8g \
     -p 0.0.0.0:9090:9090 \
-    -v ~/sourcegraph-docker/prometheus-disk:/prometheus \
+    -v ~/sourcegraph-docker/prometheus-v2-disk:/prometheus \
     -v $(pwd)/prometheus:/sg_prometheus_add_ons \
     sourcegraph/prometheus:v2.12.0@sha256:aca8cf12d41cbf5d8885ed675fa017b83ad73af96d86bbe5bcead45ca8e958f3

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -7,24 +7,21 @@ simply `docker restart prometheus` for your changes to take effect (depending on
 may respond to it as soon as you save the file).
 
 You can add `_rules.yml` and `_targets.yml` files to this directory and they will be picked up automatically.
-For example see below on how to add a target for docker itself.
 
 ### Docker metrics scraping
- 
+
 To scrape Docker itself for metrics, add the following file depending on your host machine OS:
 
 #### Linux
 
 Create `prometheus/docker_targets.yml`:
 
-#### Linux
-
 ```yaml
 - labels:
     job: docker
   targets:
     - localhost:9323
- ```
+```
 
 #### Mac & Windows
 

--- a/prometheus/docker_rules.yml
+++ b/prometheus/docker_rules.yml
@@ -1,0 +1,13 @@
+# Docker container monitoring rules
+
+groups:
+  - name: docker.rules
+    rules:
+      - record: container:process_cpu_seconds_total:ratio_rate5m
+        expr: sum by (instance) (rate(process_cpu_seconds_total[5m])) / engine_daemon_engine_cpus_cpus
+      - record: container:process_cpu_seconds_total:sum
+        expr: sum by (instance) (irate(process_cpu_seconds_total[1m]))
+      - record: container:process_resident_memory_bytes:max
+        expr: max by (instance) (process_resident_memory_bytes)
+      - record: container:process_virtual_memory_bytes:max
+        expr: max by (instance) (process_virtual_memory_bytes)


### PR DESCRIPTION
This PR cleans up some things around monitoring I observed from https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/39

- Handle upgrades so no manual intervention is needed (Prometheus v1 data is not compatible with v2).
- Add back the `docker.rules` which are needed for the "Containers" dashboard.
- Minor README/ whitespace cleanup.

Fixes sourcegraph/sourcegraph#5546