### PR TITLE
upgrade grafana

### DIFF
--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -28,7 +28,7 @@ docker run --detach \
     -e REPLACER_URL=http://replacer:3185 \
     -e ZOEKT_HOST=zoekt-webserver:6070 \
     -e LSIF_SERVER_URL=http://lsif-server:3186 \
-    -e GRAFANA_SERVER_URL=http://grafana:3000 \
+    -e GRAFANA_SERVER_URL=http://grafana:3370 \
     -v ~/sourcegraph-docker/sourcegraph-frontend-$1-disk:/mnt/cache \
     -p 0.0.0.0:$((3080 + $1)):3080 \
     sourcegraph/frontend:3.8.2

--- a/deploy-grafana.sh
+++ b/deploy-grafana.sh
@@ -15,11 +15,12 @@ docker run --detach \
     --restart=always \
     --cpus=1 \
     --memory=1g \
-    -p 0.0.0.0:3000:3000 \
+    -p 0.0.0.0:3370:3370 \
+    -e GF_SERVER_SERVE_FROM_SUB_PATH=true \
     -v ~/sourcegraph-docker/grafana-disk:/var/lib/grafana \
     -v $(pwd)/grafana/datasources:/sg_config_grafana/provisioning/datasources \
     -v $(pwd)/grafana/dashboards:/sg_grafana_additional_dashboards \
-    sourcegraph/grafana:10.0.0@sha256:f84e4260dce4e36f5d5e9c6deb393ac1e9c930ffae622c432fa86640a1f2699f
+    sourcegraph/grafana:10.0.1@sha256:16901ec40e89ed98200c92180655009acd9af002f24189ab6da53eeb48f8f20a
 
 # Add the following lines above if you wish to use an auth proxy with Grafana:
 #


### PR DESCRIPTION
- moves default port to 3370
- upgrades underlying grafana to 6.4.1
- fixes jsonnet dashboard generation for single server
- allows grafana to work outside the reverse proxy

related to https://github.com/sourcegraph/sourcegraph/pull/5910