### PR TITLE
monitoring: postgres metrics

### DIFF
--- a/deploy-postgres-exporter.sh
+++ b/deploy-postgres-exporter.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+# Description: Export Prometheus metrics from associated Postgres instance
+#
+# Disk: none
+# Network: 100mbps
+# Liveness probe: n/a
+# Ports exposed to other Sourcegraph services (Prometheus target): 9187/TCP
+# Ports exposed to the public internet: none
+#
+docker run --detach \
+    --name=postgres-exporter \
+    --network=sourcegraph \
+    --restart=always \
+    --cpus=1 \
+    --memory=1g \
+    -e DATA_SOURCE_NAME="postgresql://sourcegraph:sourcegraphd@pgsql:5432/postgres?sslmode=disable" \
+    wrouesnel/postgres_exporter:v0.7.0@sha256:785c919627c06f540d515aac88b7966f352403f73e931e70dc2cbf783146a98b
+
+echo "Deployed postgres-exporter service"

--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -21,3 +21,5 @@
     - gitserver-0:6060
     - searcher-0:6060
     - symbols-0:6060
+    - postgres-exporter:9187
+


### PR DESCRIPTION
Exposes Prometheus target postgres_exporter that publishes Postgres metrics of an associated Postgres instance.

Related to https://github.com/sourcegraph/sourcegraph/pull/6616