### PR TITLE
docker-compose: use docker volumes

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -1,7 +1,0 @@
-# This file contains default values for some environment variables that are used 
-# in docker-compose.yaml
-# See https://docs.docker.com/compose/environment-variables/ for more information.
-
-# The root storage location for various caches, gitserver, redis, postgres, etc.
-# Override this value to change where Sourcegraph stores this data.
-DATA_ROOT=~/sourcegraph-docker

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -20,7 +20,7 @@ Sourcegraph will then run in the background and across server restarts.
 Notes:
 
 - The `docker-compose.yml` file currently depends on configuration files which live in the repository, as such you must have the repository cloned onto your server.
-- Data for all services will be stored in `$DATA_ROOT` (which defaults to `~/sourcegraph-docker`).
+- Data for all services will be stored as docker volumes.
 - Use `docker ps` to inspect the Sourcegraph containers, and `docker-compose down` to teardown the deployment.
 
 ## Upgrading

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       retries: 3
       start_period: 300s
     volumes:
-      - '${DATA_ROOT}/sourcegraph-frontend-0-disk:/mnt/cache'
+      - 'sourcegraph-frontend-0:/mnt/cache'
     networks:
       - sourcegraph
     restart: always
@@ -89,7 +89,7 @@ services:
       - 'LSIF_SERVER_URL=http://lsif-server:3186'
       - 'GRAFANA_SERVER_URL=http://grafana:3000'
     volumes:
-      - '${DATA_ROOT}/sourcegraph-frontend-internal-0-disk:/mnt/cache'
+      - 'sourcegraph-frontend-internal-0:/mnt/cache'
     networks:
       - sourcegraph
     restart: always
@@ -110,7 +110,7 @@ services:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
       - JAEGER_AGENT_HOST=jaeger-agent
     volumes:
-      - '${DATA_ROOT}/gitserver-0-disk:/data/repos'
+      - 'gitserver-0:/data/repos'
     networks:
       - sourcegraph
     restart: always
@@ -132,7 +132,7 @@ services:
       - 'HOSTNAME=zoekt-webserver-0:6070'
       - 'SRC_FRONTEND_INTERNAL=http://sourcegraph-frontend-internal:3090'
     volumes:
-      - '${DATA_ROOT}/zoekt-0-shared-disk:/data/index'
+      - 'zoekt-0-shared:/data/index'
     networks:
       - sourcegraph
     restart: always
@@ -157,7 +157,7 @@ services:
       timeout: 10s
       retries: 1
     volumes:
-      - '${DATA_ROOT}/zoekt-0-shared-disk:/data/index'
+      - 'zoekt-0-shared:/data/index'
     networks:
       - sourcegraph
     restart: always
@@ -184,7 +184,7 @@ services:
       timeout: 10s
       retries: 1
     volumes:
-      - '${DATA_ROOT}/searcher-0-disk:/mnt/cache'
+      - 'searcher-0:/mnt/cache'
     networks:
       - sourcegraph
     restart: always
@@ -232,7 +232,7 @@ services:
       retries: 1
       start_period: 60s
     volumes:
-      - '${DATA_ROOT}/lsif-server-disk:/lsif-storage'
+      - 'lsif-server:/lsif-storage'
     networks:
       - sourcegraph
     restart: always
@@ -278,7 +278,7 @@ services:
       timeout: 10s
       retries: 1
     volumes:
-      - '${DATA_ROOT}/replacer-disk:/mnt/cache'
+      - 'replacer:/mnt/cache'
     networks:
       - sourcegraph
     restart: always
@@ -300,7 +300,7 @@ services:
       - JAEGER_AGENT_HOST=jaeger-agent
       - 'GITHUB_BASE_URL=http://github-proxy:3180'
     volumes:
-      - '${DATA_ROOT}/repo-updater-disk:/mnt/cache'
+      - 'repo-updater:/mnt/cache'
     networks:
       - sourcegraph
     restart: always
@@ -348,7 +348,7 @@ services:
       retries: 1
       start_period: 60s
     volumes:
-      - '${DATA_ROOT}/symbols-0-disk:/mnt/cache'
+      - 'symbols-0:/mnt/cache'
     networks:
       - sourcegraph
     restart: always
@@ -365,7 +365,7 @@ services:
     cpus: 4
     mem_limit: '8g'
     volumes:
-      - '${DATA_ROOT}/prometheus-v2-disk:/prometheus'
+      - 'prometheus-v2:/prometheus'
       - '../prometheus:/sg_prometheus_add_ons'
     ports:
       - '0.0.0.0:9090:9090'
@@ -390,7 +390,7 @@ services:
     cpus: 1
     mem_limit: '1g'
     volumes:
-      - '${DATA_ROOT}/grafana-disk:/var/lib/grafana'
+      - 'grafana:/var/lib/grafana'
       - '../grafana/datasources:/sg_config_grafana/provisioning/datasources'
       - '../grafana/dashboards:/sg_grafana_additional_dashboards'
     ports:
@@ -456,7 +456,7 @@ services:
   #     - 'CASSANDRA_RACK=rack1'
   #     - 'CASSANDRA_ENDPOINT_SNITCH=GossipingPropertyFileSnitch'
   #   volumes:
-  #     - '${DATA_ROOT}/jaeger-cassandra-disk/:/var/lib/cassandra'
+  #     - 'jaeger-cassandra:/var/lib/cassandra'
   #   networks:
   #     - sourcegraph
   #   restart: always
@@ -520,7 +520,7 @@ services:
       retries: 3
       start_period: 15s
     volumes:
-      - '${DATA_ROOT}/pgsql-disk:/data/pgdata'
+      - 'pgsql:/data/pgdata'
     networks:
       - sourcegraph
     restart: always
@@ -537,7 +537,7 @@ services:
     cpus: 1
     mem_limit: '6g'
     volumes:
-      - '${DATA_ROOT}/redis-cache-disk:/redis-data'
+      - 'redis-cache:/redis-data'
     networks:
       - sourcegraph
     restart: always
@@ -553,10 +553,26 @@ services:
     cpus: 1
     mem_limit: '6g'
     volumes:
-      - '${DATA_ROOT}/redis-store-disk:/redis-data'
+      - 'redis-store:/redis-data'
     networks:
       - sourcegraph
     restart: always
 
+volumes:
+  gitserver-0:
+  grafana:
+  #jaeger-cassandra:
+  lsif-server:
+  pgsql:
+  prometheus-v2:
+  redis-cache:
+  redis-store:
+  replacer:
+  repo-updater:
+  searcher-0:
+  sourcegraph-frontend-0:
+  sourcegraph-frontend-internal-0:
+  symbols-0:
+  zoekt-0-shared:
 networks:
   sourcegraph:


### PR DESCRIPTION
Removes the need to bind mount to local directories. Potentially also removes
some permission errors encountered.

Fixes: https://github.com/sourcegraph/sourcegraph/issues/7829

Did this while experimenting for https://github.com/sourcegraph/sourcegraph/issues/7803