### PR TITLE
pgsql: mount volume to the correct data storage location in the c…

### DIFF
--- a/deploy-pgsql.sh
+++ b/deploy-pgsql.sh
@@ -15,7 +15,7 @@ docker run --detach \
     --restart=always \
     --cpus=4 \
     --memory=2g \
-    -v ~/sourcegraph-docker/pgsql-disk:/data \
+    -v ~/sourcegraph-docker/pgsql-disk:/data/ \
     index.docker.io/sourcegraph/postgres-11.4:19-11-14_b084311b@sha256:072481559d559cfd9a53ad77c3688b5cf583117457fd452ae238a20405923297
 
 # Sourcegraph requires PostgreSQL 9.6+. Generally newer versions are better,

--- a/deploy-pgsql.sh
+++ b/deploy-pgsql.sh
@@ -15,7 +15,7 @@ docker run --detach \
     --restart=always \
     --cpus=4 \
     --memory=2g \
-    -v ~/sourcegraph-docker/pgsql-disk:/data/pgdata \
+    -v ~/sourcegraph-docker/pgsql-disk:/data \
     index.docker.io/sourcegraph/postgres-11.4:19-11-14_b084311b@sha256:072481559d559cfd9a53ad77c3688b5cf583117457fd452ae238a20405923297
 
 # Sourcegraph requires PostgreSQL 9.6+. Generally newer versions are better,

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -520,7 +520,7 @@ services:
       retries: 3
       start_period: 15s
     volumes:
-      - '${DATA_ROOT}/pgsql-disk:/data/pgdata'
+      - '${DATA_ROOT}/pgsql-disk:/data/'
     networks:
       - sourcegraph
     restart: always


### PR DESCRIPTION
The postgres volume should be mounted to `/data` instead of `/data/pgsql`: see https://github.com/sourcegraph/deploy-sourcegraph/blob/7e23bf8563b12353c7c920f21d595340e25efb65/base/pgsql/pgsql.Deployment.yaml#L51-L52 for how this is done in Kubernetes. 

Currently, it seems like **users would lose their data** if the postgres container was ever stopped and removed. I was able to verify this via [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/65):

1. Run `docker-compose up -d` to start up a new instance.
1. Create an admin account 
1. Run `docker stop pgsql` and `docker rm pgsql` 
1. Run `docker-compose` restart - see that you aren't able to load the web-page (this is expected so far)
1. Run `docker-compose up -d` to create the pgsql container again and `docker-compose restart` to refresh everything 

Notice that this takes you back to the site initialization page. If the pgsql container really was writing everything properly to the volume, you would still be able to sign in. 

After I fixed the file paths in this PR and ran through these steps again, I was able to sign in at the end (what you expect when pgsql is properly saving its data to the volume).  