### PR TITLE
redis: Make redis-cache persistent again

### DIFF
--- a/deploy-redis-cache.sh
+++ b/deploy-redis-cache.sh
@@ -3,6 +3,7 @@ set -e
 
 # Description: Redis for storing short-lived caches.
 #
+# Disk: 128GB / persistent SSD
 # Network: 100mbps
 # Liveness probe: 6379/TCP
 # Ports exposed to other Sourcegraph services: 6379/TCP 9121/TCP
@@ -14,6 +15,7 @@ docker run --detach \
     --restart=always \
     --cpus=1 \
     --memory=6g \
-    index.docker.io/sourcegraph/redis-cache:20-01-30_c903717e@sha256:c069a4589420bc6d18a7d09ebaf5416fa6407666770cf650566dfd450bba65cf
+    -v ~/sourcegraph-docker/redis-cache-disk:/redis-data \
+    index.docker.io/sourcegraph/redis-cache:20-02-03_da9d71ca@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
 
 echo "Deployed redis-cache service"

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -527,14 +527,17 @@ services:
 
   # Description: Redis for storing short-lived caches.
   #
+  # Disk: 128GB / persistent SSD
   # Ports exposed to other Sourcegraph services: 6379/TCP 9121/TCP
   # Ports exposed to the public internet: none
   #
   redis-cache:
     container_name: redis-cache
-    image: 'index.docker.io/sourcegraph/redis-cache:20-01-30_c903717e@sha256:c069a4589420bc6d18a7d09ebaf5416fa6407666770cf650566dfd450bba65cf'
+    image: 'index.docker.io/sourcegraph/redis-cache:20-02-03_da9d71ca@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56'
     cpus: 1
     mem_limit: '6g'
+    volumes:
+      - 'redis-cache:/redis-data'
     networks:
       - sourcegraph
     restart: always
@@ -562,6 +565,7 @@ volumes:
   lsif-server:
   pgsql:
   prometheus-v2:
+  redis-cache:
   redis-store:
   replacer:
   repo-updater:


### PR DESCRIPTION
This reverts commit 02c695926587e1ce9c01481ba675abc45d309e8e and updates
the image to the latest version (roll-forward).

Related to https://github.com/sourcegraph/infrastructure/pull/1829