### PR TITLE
docker-compose: explicitly define COMPOSE_PROJECT_NAME

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=docker-compose


### PR DESCRIPTION
[COMPOSE_PROJECT_NAME](https://docs.docker.com/compose/reference/envvars/#compose_project_name) defines a namespace that docker-compose prefixes all networks, containers, and volumes with. This environment variable wasn't previously set, in which case `docker-compose` defaults `COMPOSE_PROJECT_NAME` to the `basename` of the folder that contains the `docker-compose.yaml` file (literally `docker-compose` in our case). 

Not defining this variable has worked up until now, but docker-compose will treat all resources defined in `docker-compose.yaml` as brand new if the folder contains `docker-compose.yaml` was ever renamed. All the data from the old volumes will have to be manually moved over. Defining this environment variable (and making sure all docker-compose commands are run relative to this file) will prevent this from happening. 

I debated between two values for COMPOSE_PROJECT_NAME: `docker-compose` and `sourcegraph-docker-compose`. `docker-compose` should allow our existing users to upgrade without any manual migrations, but it's more ambiguous than `sourcegraph-docker-compose`. We could choose to set `COMPOSE_PROJECT_NAME=sourcegraph-docker-compose`, but we'll need to figure out a migration path for our existing users (dump the postgres database?) .