### PR TITLE
docker-compose: use caddy instead of nginx

### DIFF
--- a/caddy/builtins/http.Caddyfile
+++ b/caddy/builtins/http.Caddyfile
@@ -1,0 +1,15 @@
+# Routes all plain http requests to sourcegraph-frontend - suitable for local testing.
+#
+# Caddyfile documentation: https://caddyserver.com/docs/caddyfile
+
+# Serve all requests on port 80.
+:80
+
+# Do not modify.
+#
+# Contains the reverse proxy definition which tells Caddy to randomly
+# route requests between all frontend instances (specified by the 
+# SRC_FRONTEND_ADDRESSES environment variable.) 
+#
+# Reverse proxy directive documentation: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
+reverse_proxy {$SRC_FRONTEND_ADDRESSES}

--- a/caddy/builtins/http.Caddyfile
+++ b/caddy/builtins/http.Caddyfile
@@ -2,14 +2,6 @@
 #
 # Caddyfile documentation: https://caddyserver.com/docs/caddyfile
 
-# Serve all requests on port 80.
 :80
 
-# Do not modify.
-#
-# Contains the reverse proxy definition which tells Caddy to randomly
-# route requests between all frontend instances (specified by the 
-# SRC_FRONTEND_ADDRESSES environment variable.) 
-#
-# Reverse proxy directive documentation: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
 reverse_proxy {$SRC_FRONTEND_ADDRESSES}

--- a/caddy/builtins/https.custom-cert.Caddyfile
+++ b/caddy/builtins/https.custom-cert.Caddyfile
@@ -1,0 +1,32 @@
+# Serves Sourcegraph over HTTPS, using a custom SSL certificate/key specified
+# by the "SRC_CERT_PATH" and "SRC_KEY_PATH" environment variables.
+#
+# Caddyfile documentation: https://caddyserver.com/docs/caddyfile
+
+# The externally accessible URL for Sourcegraph (i.e. what you type in to your browser), 
+# provided via the "SRC_SITE_ADDRESS" environment variable.
+#
+# Example: sourcegraph.example.com
+{$SRC_SITE_ADDRESS}
+
+# Redirect all http traffic to https. Needed since using custom SSL certificates
+# disables automatic HTTPS feature: https://caddyserver.com/docs/automatic-https
+@http {
+   protocol http
+}
+redir @http https://{host}{uri}
+
+# Specify the paths to the custom SSL certficate/key that Caddy should use via
+# their respective environment variables.
+#
+# Caddy TLS directive documentation: https://caddyserver.com/docs/caddyfile/directives/tls
+tls {$SRC_CERT_PATH} {$SRC_KEY_PATH}
+
+# Do not modify.
+#
+# Contains the reverse proxy definition which tells Caddy to randomly
+# route requests between all frontend instances (specified by the 
+# SRC_FRONTEND_ADDRESSES environment variable.) 
+#
+# Reverse proxy directive documentation: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
+reverse_proxy {$SRC_FRONTEND_ADDRESSES}

--- a/caddy/builtins/https.custom-cert.Caddyfile
+++ b/caddy/builtins/https.custom-cert.Caddyfile
@@ -1,5 +1,5 @@
-# Serves Sourcegraph over HTTPS, using a custom SSL certificate/key specified
-# by the "SRC_CERT_PATH" and "SRC_KEY_PATH" environment variables.
+# Serves Sourcegraph over HTTPS, using a custom SSL certificate/key pair 
+# that's bind mounted from the host to /sourcegraph.pem and /sourcegraph.key.
 #
 # Caddyfile documentation: https://caddyserver.com/docs/caddyfile
 
@@ -11,6 +11,6 @@
 }
 redir @http https://{host}{uri}
 
-tls {$SRC_CERT_PATH} {$SRC_KEY_PATH}
+tls /sourcegraph.pem /sourcegraph.key
 
 reverse_proxy {$SRC_FRONTEND_ADDRESSES}

--- a/caddy/builtins/https.custom-cert.Caddyfile
+++ b/caddy/builtins/https.custom-cert.Caddyfile
@@ -3,30 +3,14 @@
 #
 # Caddyfile documentation: https://caddyserver.com/docs/caddyfile
 
-# The externally accessible URL for Sourcegraph (i.e. what you type in to your browser), 
-# provided via the "SRC_SITE_ADDRESS" environment variable.
-#
-# Example: sourcegraph.example.com
 {$SRC_SITE_ADDRESS}
 
-# Redirect all http traffic to https. Needed since using custom SSL certificates
-# disables automatic HTTPS feature: https://caddyserver.com/docs/automatic-https
+# Redirects all HTTP traffic to HTTPS (using custom SSL certificates disables the automatic HTTPS feature of Caddy, see https://caddyserver.com/docs/automatic-https)
 @http {
    protocol http
 }
 redir @http https://{host}{uri}
 
-# Specify the paths to the custom SSL certficate/key that Caddy should use via
-# their respective environment variables.
-#
-# Caddy TLS directive documentation: https://caddyserver.com/docs/caddyfile/directives/tls
 tls {$SRC_CERT_PATH} {$SRC_KEY_PATH}
 
-# Do not modify.
-#
-# Contains the reverse proxy definition which tells Caddy to randomly
-# route requests between all frontend instances (specified by the 
-# SRC_FRONTEND_ADDRESSES environment variable.) 
-#
-# Reverse proxy directive documentation: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
 reverse_proxy {$SRC_FRONTEND_ADDRESSES}

--- a/caddy/builtins/https.lets-encrypt-prod.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt-prod.Caddyfile
@@ -3,7 +3,7 @@
 #
 # 🚨 Warning: If your DNS and Caddy configuration aren't properly configured (as 
 #             specified in https://caddyserver.com/docs/automatic-https), you can 
-#             run into Let's Encrypt rate limits which can block your certfificates 
+#             run into Let's Encrypt rate limits which can block your certificates 
 #             for up to a week. 
 #             It's strongly recommened that you use the staging Caddyfile 
 #             (https.lets-encrypt-staging.Caddyfile) to test your

--- a/caddy/builtins/https.lets-encrypt-prod.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt-prod.Caddyfile
@@ -3,11 +3,18 @@
 #
 # 🚨 Warning: If your DNS and Caddy configuration aren't properly configured (as 
 #             specified in https://caddyserver.com/docs/automatic-https), you can 
-#             Let's Encrypt rate limits which can block your certfificates for up to
-#             a week. 
+#             run into Let's Encrypt rate limits which can block your certfificates 
+#             for up to a week. 
+#             It's strongly recommened that you use the staging Caddyfile 
+#             (https.lets-encrypt-staging.Caddyfile) to test your
+#             configuration before swithching to this production one. 
 #
 # Caddyfile documentation: https://caddyserver.com/docs/caddyfile
 #
+
+{
+    email {$SRC_ACME_EMAIL}
+}
 
 {$SRC_SITE_ADDRESS}
 

--- a/caddy/builtins/https.lets-encrypt-prod.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt-prod.Caddyfile
@@ -7,7 +7,7 @@
 #             for up to a week. 
 #             It's strongly recommened that you use the staging Caddyfile 
 #             (https.lets-encrypt-staging.Caddyfile) to test your
-#             configuration before swithching to this production one. 
+#             configuration before switching to this production one. 
 #
 # Caddyfile documentation: https://caddyserver.com/docs/caddyfile
 #

--- a/caddy/builtins/https.lets-encrypt-staging.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt-staging.Caddyfile
@@ -1,0 +1,27 @@
+# Serves Sourcegraph over HTTPS, using Caddy's automatic HTTPS certificate feature:
+# https://caddyserver.com/docs/automatic-https
+# 
+# Note: This configuration uses Let's Encrypt's staging environment. This will 
+# allow you to ensure that everything is correctly configured (with a reduced 
+# chance of running into rate limit issues). Note that using this configuration
+# issues a fake certificate (for testing purposes) instead of a trusted one.
+#
+# 🚨 Warning: If your DNS and Caddy configuration aren't properly configured (as 
+#             specified in https://caddyserver.com/docs/automatic-https), you can 
+#             run into Let's Encrypt rate limits which can block your certfificates 
+#             for up to a week. 
+#             It's strongly recommened that you use this Caddyfile to test your
+#             configuration before swithching to the production one. 
+#
+# Caddyfile documentation: https://caddyserver.com/docs/caddyfile
+#
+
+{
+    # Use Let's Encrypt's staging environment
+    acme_ca "https://acme-staging-v02.api.letsencrypt.org/directory"
+    email {$SRC_ACME_EMAIL}
+}
+
+{$SRC_SITE_ADDRESS}
+
+reverse_proxy {$SRC_FRONTEND_ADDRESSES}

--- a/caddy/builtins/https.lets-encrypt-staging.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt-staging.Caddyfile
@@ -8,7 +8,7 @@
 #
 # 🚨 Warning: If your DNS and Caddy configuration aren't properly configured (as 
 #             specified in https://caddyserver.com/docs/automatic-https), you can 
-#             run into Let's Encrypt rate limits which can block your certfificates 
+#             run into Let's Encrypt rate limits which can block your certificates 
 #             for up to a week. 
 #             It's strongly recommened that you use this Caddyfile to test your
 #             configuration before switching to the production one. 

--- a/caddy/builtins/https.lets-encrypt-staging.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt-staging.Caddyfile
@@ -11,7 +11,7 @@
 #             run into Let's Encrypt rate limits which can block your certfificates 
 #             for up to a week. 
 #             It's strongly recommened that you use this Caddyfile to test your
-#             configuration before swithching to the production one. 
+#             configuration before switching to the production one. 
 #
 # Caddyfile documentation: https://caddyserver.com/docs/caddyfile
 #

--- a/caddy/builtins/https.lets-encrypt.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt.Caddyfile
@@ -1,20 +1,14 @@
-# Serves Sourcegraph over HTTPS, using automatically provisioned certficates 
-# provided by Caddy. See https://caddyserver.com/docs/automatic-https for more information 
-# about how this feature works, caveats, and warnings. 
+# Serves Sourcegraph over HTTPS, using Caddy's automatic HTTPS certificate feature:
+# https://caddyserver.com/docs/automatic-https
+#
+# 🚨 Warning: If your DNS and Caddy configuration aren't properly configured (as 
+#             specified in https://caddyserver.com/docs/automatic-https), you can 
+#             Let's Encrypt rate limits which can block your certfificates for up to
+#             a week. 
 #
 # Caddyfile documentation: https://caddyserver.com/docs/caddyfile
-
-# The externally accessible URL for Sourcegraph (i.e. what you type in to your browser), 
-# provided via the "SRC_SITE_ADDRESS" environment variable.
 #
-# Example: sourcegraph.example.com
+
 {$SRC_SITE_ADDRESS}
 
-# Contains the reverse proxy definition which tells Caddy to randomly
-# route requests between all frontend instances (specified by the 
-# SRC_FRONTEND_ADDRESSES environment variable.)
-#
-# Do not modify.
-#
-# Reverse proxy directive documentation: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
 reverse_proxy {$SRC_FRONTEND_ADDRESSES}

--- a/caddy/builtins/https.lets-encrypt.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt.Caddyfile
@@ -1,0 +1,20 @@
+# Serves Sourcegraph over HTTPS, using automatically provisioned certficates 
+# provided by Caddy. See https://caddyserver.com/docs/automatic-https for more information 
+# about how this feature works, caveats, and warnings. 
+#
+# Caddyfile documentation: https://caddyserver.com/docs/caddyfile
+
+# The externally accessible URL for Sourcegraph (i.e. what you type in to your browser), 
+# provided via the "SRC_SITE_ADDRESS" environment variable.
+#
+# Example: sourcegraph.example.com
+{$SRC_SITE_ADDRESS}
+
+# Contains the reverse proxy definition which tells Caddy to randomly
+# route requests between all frontend instances (specified by the 
+# SRC_FRONTEND_ADDRESSES environment variable.)
+#
+# Do not modify.
+#
+# Reverse proxy directive documentation: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
+reverse_proxy {$SRC_FRONTEND_ADDRESSES}

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       - 'XDG_DATA_HOME=/caddy-storage/data'
       - 'XDG_CONFIG_HOME=/caddy-storage/config'
       - 'SRC_FRONTEND_ADDRESSES="sourcegraph-frontend-0:3080"'
-      # Uncomment / update the following line when using HTTPS with either Let's Encrypt or custom certficates
+      # Uncomment & update this line when using Let's Encrypt or custom HTTPS certificates:
       # - 'SRC_SITE_ADDRESS="sourcegraph.example.com"'
       # Uncomment / update the following line when using HTTPS with Let's Encrypt
       # - 'SRC_ACME_EMAIL=admin@example.com'

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
   # Follow the directions in the comments below to swap between these configurations.
   #
   # If none of these built-in configurations suit your needs, then you can create your own Caddyfile by referencing
-  # the official documentation: https://caddyserver.com/docs/caddyfile
+  # https://caddyserver.com/docs/caddyfile
   caddy:
     container_name: caddy
     image: 'index.docker.io/caddy/caddy:alpine@sha256:b0f0a763527ca11a555bc5b5f942fa2d84ae0c90b0b60e47d0426ff884dd10ad'

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
   #
   # Follow the directions in the comments below to swap between these configurations.
   #
-  # If none of these built-in configurations suit your needs, then you can create your own Caddyfile by referencing
+  # If none of these built-in configurations suit your needs, then you can create your own Caddyfile, see:
   # https://caddyserver.com/docs/caddyfile
   caddy:
     container_name: caddy

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       - 'SRC_FRONTEND_ADDRESSES="sourcegraph-frontend-0:3080"'
       # Uncomment & update this line when using Let's Encrypt or custom HTTPS certificates:
       # - 'SRC_SITE_ADDRESS="sourcegraph.example.com"'
-      # Uncomment / update the following line when using HTTPS with Let's Encrypt
+      # Uncomment & update the following line when using HTTPS with Let's Encrypt
       # - 'SRC_ACME_EMAIL=admin@example.com'
     volumes:
       - 'caddy:/caddy-storage'

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       # Comment out the following line when using HTTPS with either Let's Encrypt or custom certficates
       - '../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile'
       #
-      # Uncomment the following line when using HTTPS with Let's Encrypt's staging environment (recommened before using prod)
+      # Uncomment the following line when using HTTPS with Let's Encrypt's staging environment
       # - '../caddy/builtins/https.lets-encrypt-staging.Caddyfile:/etc/caddy/Caddyfile'
       #
       # Uncomment the following line when using HTTPS with Let's Encrypt's production environment

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -40,6 +40,7 @@ services:
       # - '../caddy/builtins/https.lets-encrypt-staging.Caddyfile:/etc/caddy/Caddyfile'
       #
       # Uncomment the following line when using HTTPS with Let's Encrypt's production environment
+      # IMPORTANT: Strongly recommended to test with the staging configuration above first, see that file for details. 
       # - '../caddy/builtins/https.lets-encrypt-prod.Caddyfile:/etc/caddy/Caddyfile'
       #
       # Uncomment the following line when using HTTPS with custom certificates

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -6,48 +6,12 @@ services:
   # Ports exposed to other Sourcegraph services: none
   # Ports exposed to the public internet: 80 (HTTP) and 443 (HTTPS)
   #
-  # Notes:
+  # Sourcegraph ships with a few builtin templates that cover some common HTTP/HTTPS configurations:
+  # - HTTP only (default)
+  # - HTTPS with Let's Encrypt
+  # - HTTPS with custom certificates
   #
-  # 1. The "SRC_FRONTEND_ADDRESSES" environment variable is a space-delimited list of network addresses
-  # for all the frontend addresses that Caddy should proxy. This evironment variable must be updated when
-  # scaling the number of sourcegraph-frontend replicas.
-  #
-  # 2. Sourcegraph ships with a few builtin templates that cover many common HTTP/HTTPS configurations:
-  #
-  # http.Caddyfile (default): Serves Sourcegraph over port 80. Suitable for local testing.
-  #
-  # https.lets-encrypt.Caddyfile: Serves Sourcegraph over HTTPS using Caddy's built-in Let's Encrypt
-  #                               feature. See https://caddyserver.com/docs/automatic-https for more information
-  #                               about how this feature works, caveats, and warnings.
-  #                               This configuration requires that the following environment variable(s)
-  #                               are set:
-  #                               - "SRC_SITE_ADDRESS": The externally accessible URL for Sourcegraph
-  #                                                     (i.e. what you type in to your browser). Example:
-  #                                                     "sourcegraph.example.com"
-  #
-  # https.custom-cert.Caddyfile: Serves Sourcegraph over HTTPS using a custom SSL certficate / key that
-  #                              you provide.
-  #                              This configuration requires that the following environment
-  #                              variable(s) are set:
-  #                              - "SRC_SITE_ADDRESS": The externally accessible URL for Sourcegraph
-  #                                                    (i.e. what you type in to your browser). Example:
-  #                                                    "sourcegraph.example.com"
-  #                              - "SRC_CERT_PATH":    The absolute path (inside the docker container) to your
-  #                                                    custom SSL certficate. Example: "/sourcegraph.pem"
-  #                                                    Note: The certficate must be bind mounted from the host machine
-  #                                                    to the Docker container.
-  #                              - "SRC_KEY_PATH":     The absolute path (inside the docker container) to your
-  #                                                    custom SSL certficate's key. Example: "/sourcegraph.key"
-  #                                                    Note: The key must be bind mounted from the host machine
-  #                                                    to the Docker container.
-  #
-  # You can swap between these configurations by setting their corresponding environment variables and
-  # editing the volume mount that mounts one of the above files into the container's /etc/caddy/Caddyfile.
-  # For example, if you wanted to use a custom certificate for https (https.custom-cert.Caddyfile) you'd do the following:
-  #   1) Set the "SRC_SITE_ADDRESS", "SRC_CERT_PATH", and "SRC_KEY_PATH" enviroment variables (and mount the local cert/key into the container).
-  #   2) Change the Caddyfile volume mount
-  #      from "- ../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile"
-  #      to "- ../caddy/builtins/https.lets-encrypt.Caddyfile:/etc/caddy/Caddyfile"
+  # Follow the directions in the comments below to swap between these configurations.
   #
   # If none of these built-in configurations suit your needs, then you can create your own Caddyfile by referencing
   # the official documentation: https://caddyserver.com/docs/caddyfile
@@ -60,13 +24,24 @@ services:
       - 'XDG_DATA_HOME=/caddy-storage/data'
       - 'XDG_CONFIG_HOME=/caddy-storage/config'
       - 'SRC_FRONTEND_ADDRESSES="sourcegraph-frontend-0:3080"'
+      # Uncomment / update the following line when using HTTPS with either Let's Encrypt or custom certficates
       # - 'SRC_SITE_ADDRESS="sourcegraph.example.com"'
-      # - 'SRC_CERT_PATH=/sourcegraph.pem'
-      # - 'SRC_KEY_PATH=/sourcegraph.key'
     volumes:
       - 'caddy:/caddy-storage'
+      #
+      # Comment out the following line when using HTTPS with either Let's Encrypt or custom certficates
       - '../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile'
+      #
+      # Uncomment the following line when using HTTPS with Let's Encrypt
+      # - '../caddy/builtins/https.lets-encrypt.Caddyfile:/etc/caddy/Caddyfile'
+      #
+      # Uncomment the following line when using HTTPS with custom certificates
+      # - '../caddy/builtins/https.custom-cert.Caddyfile:/etc/caddy/Caddyfile'
+      #
+      # Uncomment / update the following line when using HTTPS with custom certficates
       # - '/LOCAL/CERT/PATH.pem:/sourcegraph.pem'
+      #
+      # Uncomment / update the following line when using HTTPS with custom certficates
       # - '/LOCAL/KEY/PATH.pem:/sourcegraph.key'
     ports:
       - '0.0.0.0:80:80'

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
   # Sourcegraph ships with a few builtin templates that cover common HTTP/HTTPS configurations:
   # - HTTP only (default)
   # - HTTPS with Let's Encrypt (staging/production - strongly recommended that you test with the staging
-  #                            configuration first, see caddy/builtins/https.lets-encrypt-staging.Caddyfile
   #                            for more info)
   # - HTTPS with custom certificates
   #

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -2,23 +2,75 @@ version: '2.4'
 services:
   # Description: Acts as a reverse proxy for all of the sourcegraph-frontend instances
   #
-  # Disk: none
+  # Disk: 1GB / persistent SSD
   # Ports exposed to other Sourcegraph services: none
-  # Ports exposed to the public internet: 7080 (HTTP) and/or 7443 (HTTPS)
+  # Ports exposed to the public internet: 80 (HTTP) and 443 (HTTPS)
   #
-  # Note: nginx/nginx/sourcegraph_backend.conf lists all of the sourcegraph-frontend
-  # network addresses that Nginx should proxy. nginx/nginx/sourcegraph_backend.conf
-  # needs to be updated with new addresses when scaling the number of soucegraph-frontend
-  # replicas.
-  nginx:
-    container_name: nginx
-    image: 'index.docker.io/library/nginx:1.17.7@sha256:8aa7f6a9585d908a63e5e418dc5d14ae7467d2e36e1ab4f0d8f9d059a3d071ce'
+  # Notes:
+  #
+  # 1. The "SRC_FRONTEND_ADDRESSES" environment variable is a space-delimited list of network addresses
+  # for all the frontend addresses that Caddy should proxy. This evironment variable must be updated when
+  # scaling the number of sourcegraph-frontend replicas.
+  #
+  # 2. Sourcegraph ships with a few builtin templates that cover many common HTTP/HTTPS configurations:
+  #
+  # http.Caddyfile (default): Serves Sourcegraph over port 80. Suitable for local testing.
+  #
+  # https.lets-encrypt.Caddyfile: Serves Sourcegraph over HTTPS using Caddy's built-in Let's Encrypt
+  #                               feature. See https://caddyserver.com/docs/automatic-https for more information
+  #                               about how this feature works, caveats, and warnings.
+  #                               This configuration requires that the following environment variable(s)
+  #                               are set:
+  #                               - "SRC_SITE_ADDRESS": The externally accessible URL for Sourcegraph
+  #                                                     (i.e. what you type in to your browser). Example:
+  #                                                     "sourcegraph.example.com"
+  #
+  # https.custom-cert.Caddyfile: Serves Sourcegraph over HTTPS using a custom SSL certficate / key that
+  #                              you provide.
+  #                              This configuration requires that the following environment
+  #                              variable(s) are set:
+  #                              - "SRC_SITE_ADDRESS": The externally accessible URL for Sourcegraph
+  #                                                    (i.e. what you type in to your browser). Example:
+  #                                                    "sourcegraph.example.com"
+  #                              - "SRC_CERT_PATH":    The absolute path (inside the docker container) to your
+  #                                                    custom SSL certficate. Example: "/sourcegraph.pem"
+  #                                                    Note: The certficate must be bind mounted from the host machine
+  #                                                    to the Docker container.
+  #                              - "SRC_KEY_PATH":     The absolute path (inside the docker container) to your
+  #                                                    custom SSL certficate's key. Example: "/sourcegraph.key"
+  #                                                    Note: The key must be bind mounted from the host machine
+  #                                                    to the Docker container.
+  #
+  # You can swap between these configurations by setting their corresponding environment variables and
+  # editing the volume mount that mounts one of the above files into the container's /etc/caddy/Caddyfile.
+  # For example, if you wanted to use a custom certificate for https (https.custom-cert.Caddyfile) you'd do the following:
+  #   1) Set the "SRC_SITE_ADDRESS", "SRC_CERT_PATH", and "SRC_KEY_PATH" enviroment variables (and mount the local cert/key into the container).
+  #   2) Change the Caddyfile volume mount
+  #      from "- ../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile"
+  #      to "- ../caddy/builtins/https.lets-encrypt.Caddyfile:/etc/caddy/Caddyfile"
+  #
+  # If none of these built-in configurations suit your needs, then you can create your own Caddyfile by referencing
+  # the official documentation: https://caddyserver.com/docs/caddyfile
+  caddy:
+    container_name: caddy
+    image: 'index.docker.io/caddy/caddy:alpine@sha256:b0f0a763527ca11a555bc5b5f942fa2d84ae0c90b0b60e47d0426ff884dd10ad'
     cpus: 1
     mem_limit: '1g'
+    environment:
+      - 'XDG_DATA_HOME=/caddy-storage/data'
+      - 'XDG_CONFIG_HOME=/caddy-storage/config'
+      - 'SRC_FRONTEND_ADDRESSES="sourcegraph-frontend-0:3080"'
+      # - 'SRC_SITE_ADDRESS="sourcegraph.example.com"'
+      # - 'SRC_CERT_PATH=/sourcegraph.pem'
+      # - 'SRC_KEY_PATH=/sourcegraph.key'
     volumes:
-      - '../nginx:/etc/nginx'
+      - 'caddy:/caddy-storage'
+      - '../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile'
+      # - '/LOCAL/CERT/PATH.pem:/sourcegraph.pem'
+      # - '/LOCAL/KEY/PATH.pem:/sourcegraph.key'
     ports:
-      - '0.0.0.0:80:7080'
+      - '0.0.0.0:80:80'
+      - '0.0.0.0:443:443'
     networks:
       - sourcegraph
     restart: always
@@ -559,6 +611,7 @@ services:
     restart: always
 
 volumes:
+  caddy:
   gitserver-0:
   grafana:
   #jaeger-cassandra:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
   #
   # Sourcegraph ships with a few builtin templates that cover common HTTP/HTTPS configurations:
   # - HTTP only (default)
-  # - HTTPS with Let's Encrypt (staging/production - strongly recommended that you test with the staging
+  # - HTTPS with Let's Encrypt
   # - HTTPS with custom certificates
   #
   # Follow the directions in the comments below to swap between these configurations.
@@ -26,6 +26,7 @@ services:
       - 'SRC_FRONTEND_ADDRESSES="sourcegraph-frontend-0:3080"'
       # Uncomment & update this line when using Let's Encrypt or custom HTTPS certificates:
       # - 'SRC_SITE_ADDRESS="sourcegraph.example.com"'
+      #
       # Uncomment & update the following line when using HTTPS with Let's Encrypt
       # - 'SRC_ACME_EMAIL=admin@example.com'
     volumes:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
   # Sourcegraph ships with a few builtin templates that cover common HTTP/HTTPS configurations:
   # - HTTP only (default)
   # - HTTPS with Let's Encrypt (staging/production - strongly recommended that you test with the staging
-  #                            for more info)
   # - HTTPS with custom certificates
   #
   # Follow the directions in the comments below to swap between these configurations.

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
   # Ports exposed to other Sourcegraph services: none
   # Ports exposed to the public internet: 80 (HTTP) and 443 (HTTPS)
   #
-  # Sourcegraph ships with a few builtin templates that cover some common HTTP/HTTPS configurations:
+  # Sourcegraph ships with a few builtin templates that cover common HTTP/HTTPS configurations:
   # - HTTP only (default)
   # - HTTPS with Let's Encrypt (staging/production - strongly recommended that you test with the staging
   #                            configuration first, see caddy/builtins/https.lets-encrypt-staging.Caddyfile

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -8,7 +8,9 @@ services:
   #
   # Sourcegraph ships with a few builtin templates that cover some common HTTP/HTTPS configurations:
   # - HTTP only (default)
-  # - HTTPS with Let's Encrypt
+  # - HTTPS with Let's Encrypt (staging/production - strongly recommended that you test with the staging
+  #                            configuration first, see caddy/builtins/https.lets-encrypt-staging.Caddyfile
+  #                            for more info)
   # - HTTPS with custom certificates
   #
   # Follow the directions in the comments below to swap between these configurations.
@@ -26,14 +28,19 @@ services:
       - 'SRC_FRONTEND_ADDRESSES="sourcegraph-frontend-0:3080"'
       # Uncomment / update the following line when using HTTPS with either Let's Encrypt or custom certficates
       # - 'SRC_SITE_ADDRESS="sourcegraph.example.com"'
+      # Uncomment / update the following line when using HTTPS with Let's Encrypt
+      # - 'SRC_ACME_EMAIL=admin@example.com'
     volumes:
       - 'caddy:/caddy-storage'
       #
       # Comment out the following line when using HTTPS with either Let's Encrypt or custom certficates
       - '../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile'
       #
-      # Uncomment the following line when using HTTPS with Let's Encrypt
-      # - '../caddy/builtins/https.lets-encrypt.Caddyfile:/etc/caddy/Caddyfile'
+      # Uncomment the following line when using HTTPS with Let's Encrypt's staging environment (recommened before using prod)
+      # - '../caddy/builtins/https.lets-encrypt-staging.Caddyfile:/etc/caddy/Caddyfile'
+      #
+      # Uncomment the following line when using HTTPS with Let's Encrypt's production environment
+      # - '../caddy/builtins/https.lets-encrypt-prod.Caddyfile:/etc/caddy/Caddyfile'
       #
       # Uncomment the following line when using HTTPS with custom certificates
       # - '../caddy/builtins/https.custom-cert.Caddyfile:/etc/caddy/Caddyfile'

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -20,8 +20,8 @@ services:
   caddy:
     container_name: caddy
     image: 'index.docker.io/caddy/caddy:alpine@sha256:b0f0a763527ca11a555bc5b5f942fa2d84ae0c90b0b60e47d0426ff884dd10ad'
-    cpus: 1
-    mem_limit: '1g'
+    cpus: 4
+    mem_limit: '4g'
     environment:
       - 'XDG_DATA_HOME=/caddy-storage/data'
       - 'XDG_CONFIG_HOME=/caddy-storage/config'


### PR DESCRIPTION
This PR switches the default reverse proxy from nginx over to [Caddy 2](https://caddyserver.com/). In addition, default configurations for exposing sourcegraph over HTTP, HTTPS with lets encrypt, and HTTP with custom certs are provided. 

Many of our users will need to modify the nginx configuration in order to expose Sourcegraph properly. However: 

1. Our nginx configuration is quite verbose. This:

- makes it quite difficult to see the configuration points that user is 
- makes the upgrading process more difficult since the user will need to solve these large merge conflicts on each update 

1. Since we switched to nginx, we have lost the ability to easily provision Lets Encrypt certs - which makes it harder for users to share their new Sourcegraph instance with the rest of their team 

Switching to [Caddy](https://caddyserver.com/) introduces many benefits:

1. Caddy's defaults are much saner that Nginx's. This removes a ton of boilerplate from the configuration files. For example, a working HTTPS deployment of Sourcegraph with Let's Encrypt certs seems to be just:

```Caddyfile
sourcegraph.example.com

reverse_proxy {$SRC_FRONTEND_ADDRESSES}
```

1. Caddy's [automatic HTTPS](https://caddyserver.com/docs/automatic-https) lets our users seamlessly provision working certificates as long as they can control their domain records

1. Caddy's configuration can be [driven through environment variables](https://caddyserver.com/docs/caddyfile-tutorial#environment-variables). This means for the common configurations that I provided, that our users **don't have to make any manual edits** to those files. All they have to do is set 1-3 environment variables on the docker-compose definition and swap the Caddyfile that they're mounting. These environment variables are clearly documented.



---

Notes: 

- Caddy 2 uses the Apache license, so we can safely include it in our application: https://github.com/caddyserver/caddy/blob/v2/LICENSE

- Caddy 2 is still in beta, but it's advertised as production ready. Our configuration is so vanilla that I don't anticipate much churn in between Caddy releases.

- Power users can still easily compose their own Caddyfile (or use something else entirely if they have more specialized needs). 