### PR TITLE
Federate lsif-server metrics

### DIFF
--- a/deploy-lsif-server.sh
+++ b/deploy-lsif-server.sh
@@ -17,9 +17,9 @@ docker run --detach \
     --cpus=2 \
     --memory=2g \
     -e GOMAXPROCS=2 \
-    -e LSIF_NUM_SERVERS=1 \
-    -e LSIF_NUM_DUMP_MANAGERS=1 \
-    -e LSIF_NUM_DUMP_PROCESSORS=1 \
+    -e NUM_APIS=1 \
+    -e NUM_BUNDLE_MANAGERS=1 \
+    -e NUM_WORKERS=1 \
     -e LSIF_STORAGE_ROOT=/lsif-storage \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -v ~/sourcegraph-docker/lsif-server-disk:/lsif-storage \

--- a/deploy-lsif-server.sh
+++ b/deploy-lsif-server.sh
@@ -6,8 +6,8 @@ source ./replicas.sh
 #
 # Disk: 200GB / persistent SSD
 # Network: 100mbps
-# Liveness probe: n/a
-# Ports exposed to other Sourcegraph services: 3186/TCP (server) 3187/TCP (worker)
+# Liveness probe: HTTP GET http://lsif-server:3186/healthz
+# Ports exposed to other Sourcegraph services: 3186/TCP (server) 9090/TCP (prometheus)
 # Ports exposed to the public internet: none
 #
 docker run --detach \
@@ -17,6 +17,8 @@ docker run --detach \
     --cpus=2 \
     --memory=2g \
     -e GOMAXPROCS=2 \
+    -e LSIF_NUM_SERVERS=1 \
+    -e LSIF_NUM_WORKERS=1 \
     -e LSIF_STORAGE_ROOT=/lsif-storage \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -v ~/sourcegraph-docker/lsif-server-disk:/lsif-storage \

--- a/deploy-lsif-server.sh
+++ b/deploy-lsif-server.sh
@@ -17,9 +17,6 @@ docker run --detach \
     --cpus=2 \
     --memory=2g \
     -e GOMAXPROCS=2 \
-    -e NUM_APIS=1 \
-    -e NUM_BUNDLE_MANAGERS=1 \
-    -e NUM_WORKERS=1 \
     -e PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL=http://localhost:3187 \
     -e PRECISE_CODE_INTEL_API_SERVER_URL=http://localhost:3186 \
     -e LSIF_STORAGE_ROOT=/lsif-storage \

--- a/deploy-lsif-server.sh
+++ b/deploy-lsif-server.sh
@@ -17,8 +17,6 @@ docker run --detach \
     --cpus=2 \
     --memory=2g \
     -e GOMAXPROCS=2 \
-    -e PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL=http://localhost:3187 \
-    -e PRECISE_CODE_INTEL_API_SERVER_URL=http://localhost:3186 \
     -e LSIF_STORAGE_ROOT=/lsif-storage \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -v ~/sourcegraph-docker/lsif-server-disk:/lsif-storage \

--- a/deploy-lsif-server.sh
+++ b/deploy-lsif-server.sh
@@ -18,7 +18,8 @@ docker run --detach \
     --memory=2g \
     -e GOMAXPROCS=2 \
     -e LSIF_NUM_SERVERS=1 \
-    -e LSIF_NUM_WORKERS=1 \
+    -e LSIF_NUM_DUMP_MANAGERS=1 \
+    -e LSIF_NUM_DUMP_PROCESSORS=1 \
     -e LSIF_STORAGE_ROOT=/lsif-storage \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -v ~/sourcegraph-docker/lsif-server-disk:/lsif-storage \

--- a/deploy-lsif-server.sh
+++ b/deploy-lsif-server.sh
@@ -20,6 +20,8 @@ docker run --detach \
     -e NUM_APIS=1 \
     -e NUM_BUNDLE_MANAGERS=1 \
     -e NUM_WORKERS=1 \
+    -e PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL=http://localhost:3187 \
+    -e PRECISE_CODE_INTEL_API_SERVER_URL=http://localhost:3186 \
     -e LSIF_STORAGE_ROOT=/lsif-storage \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -v ~/sourcegraph-docker/lsif-server-disk:/lsif-storage \

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -249,7 +249,7 @@ services:
   # Description: LSIF HTTP server for code intelligence.
   #
   # Disk: 200GB / persistent SSD
-  # Ports exposed to other Sourcegraph services: 3186/TCP (server) 3187/TCP (worker)
+  # Ports exposed to other Sourcegraph services: 3186/TCP (server) 9090/TCP (prometheus)
   # Ports exposed to the public internet: none
   #
   lsif-server:
@@ -259,6 +259,8 @@ services:
     mem_limit: '2g'
     environment:
       - GOMAXPROCS=2
+      - LSIF_NUM_SERVERS=1
+      - LSIF_NUM_WORKERS=1
       - LSIF_STORAGE_ROOT=/lsif-storage
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
     healthcheck:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -268,6 +268,8 @@ services:
       - NUM_APIS=1
       - NUM_BUNDLE_MANAGERS=1
       - NUM_WORKERS=1
+      - PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL=http://localhost:3187
+      - PRECISE_CODE_INTEL_API_SERVER_URL=http://localhost:3186
       - LSIF_STORAGE_ROOT=/lsif-storage
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
     healthcheck:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -265,9 +265,6 @@ services:
     mem_limit: '2g'
     environment:
       - GOMAXPROCS=2
-      - NUM_APIS=1
-      - NUM_BUNDLE_MANAGERS=1
-      - NUM_WORKERS=1
       - PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL=http://localhost:3187
       - PRECISE_CODE_INTEL_API_SERVER_URL=http://localhost:3186
       - LSIF_STORAGE_ROOT=/lsif-storage

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -260,7 +260,8 @@ services:
     environment:
       - GOMAXPROCS=2
       - LSIF_NUM_SERVERS=1
-      - LSIF_NUM_WORKERS=1
+      - LSIF_NUM_DUMP_MANAGERS=1
+      - LSIF_NUM_DUMP_PROCESSORS=1
       - LSIF_STORAGE_ROOT=/lsif-storage
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
     healthcheck:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -259,9 +259,9 @@ services:
     mem_limit: '2g'
     environment:
       - GOMAXPROCS=2
-      - LSIF_NUM_SERVERS=1
-      - LSIF_NUM_DUMP_MANAGERS=1
-      - LSIF_NUM_DUMP_PROCESSORS=1
+      - NUM_APIS=1
+      - NUM_BUNDLE_MANAGERS=1
+      - NUM_WORKERS=1
       - LSIF_STORAGE_ROOT=/lsif-storage
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
     healthcheck:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -265,8 +265,6 @@ services:
     mem_limit: '2g'
     environment:
       - GOMAXPROCS=2
-      - PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL=http://localhost:3187
-      - PRECISE_CODE_INTEL_API_SERVER_URL=http://localhost:3186
       - LSIF_STORAGE_ROOT=/lsif-storage
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
     healthcheck:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,47 @@
+# Prometheus global config
+global:
+  scrape_interval: 30s # Scrape services for updated metrics every 30s. Default is 1m.
+  evaluation_interval: 30s # Evaluate rules every 30s. Default is 1m.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # deploy-sourcegraph-docker does not yet use prometheus alerts
+          # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  - "*_rules.yml"
+  - "/sg_prometheus_add_ons/*_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape for metrics:
+scrape_configs:
+  # Scrape prometheus itself for metrics.
+  - job_name: "prometheus"
+    static_configs:
+        - targets: ["localhost:9090"]
+
+  - job_name: "sg"
+    file_sd_configs:
+      - files:
+          - "/sg_prometheus_add_ons/*_targets.yml"
+
+## Note: the content above is taken from sourcegraph/sourcegraph/docker-images/prometheus/config/prometheus.yml
+## I'm not currently sure how to configure the below in an external file via file_sd_configs.
+##
+## TODO(eric,uwedeportivo) - find a way to express what's below in an extensible way so we can 
+## just add config files in this directory instead of overwriting the entire main configuration.
+
+  - job_name: federate
+    honor_labels: true
+    metrics_path: /federate
+    params:
+      'match[]':
+        - '{__name__=~"lsif_.*"}'
+
+    static_configs:
+      - targets:
+        - lsif-server:9090

--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -12,8 +12,6 @@
     - query-runner:6060
     - repo-updater:6060
     - syntect-server:6060
-    - lsif-server:3186
-    - lsif-server:3187
     # Add new entries here for every searcher/symbol/gitserver replica.
     - zoekt-indexserver-0:6072
     - replacer-0:6060


### PR DESCRIPTION
**Note**: This should not be merged until the docker tags have been updated in the deployment, otherwise we will lose metrics for LSIF processes as prometheus is not available in the current containers.

https://github.com/sourcegraph/sourcegraph/pull/8951 introduced a Prometheus server inside the lsif-server containers to scrape and federate metrics from a dynamic number of workers. This introduces a new annotation option `prometheus.io/federate` that enables the `/federate` endpoint to be scraped for all global metrics.