### PR TITLE
Add LSIF_API_SERVER_URL envvar to replace LSIF_SERVER_URL

### DIFF
--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -26,7 +26,10 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e REPO_UPDATER_URL=http://repo-updater:3182 \
     -e REPLACER_URL=http://replacer:3185 \
+    # remove after 3.15
     -e LSIF_SERVER_URL=http://lsif-server:3186 \
+    # used after 3.15
+    -e LSIF_API_SERVER_URL=http://lsif-server:3186 \
     -e GRAFANA_SERVER_URL=http://grafana:3000 \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \
     -v ~/sourcegraph-docker/sourcegraph-frontend-internal-0-disk:/mnt/cache \

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -27,7 +27,10 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e REPO_UPDATER_URL=http://repo-updater:3182 \
     -e REPLACER_URL=http://replacer:3185 \
+    # remove after 3.15
     -e LSIF_SERVER_URL=http://lsif-server:3186 \
+    # used after 3.15
+    -e LSIF_API_SERVER_URL=http://lsif-server:3186 \
     -e GRAFANA_SERVER_URL=http://grafana:3370 \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \
     -v ~/sourcegraph-docker/sourcegraph-frontend-$1-disk:/mnt/cache \

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -84,7 +84,10 @@ services:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
       - 'REPO_UPDATER_URL=http://repo-updater:3182'
       - 'REPLACER_URL=http://replacer:3185'
+      # remove after 3.15
       - 'LSIF_SERVER_URL=http://lsif-server:3186'
+      # used after 3.15
+      - 'LSIF_API_SERVER_URL=http://lsif-server:3186'
       - 'GRAFANA_SERVER_URL=http://grafana:3370'
       - 'GITHUB_BASE_URL=http://github-proxy:3180'
     healthcheck:
@@ -121,7 +124,10 @@ services:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
       - 'REPO_UPDATER_URL=http://repo-updater:3182'
       - 'REPLACER_URL=http://replacer:3185'
+      # remove after 3.15
       - 'LSIF_SERVER_URL=http://lsif-server:3186'
+      # used after 3.15
+      - 'LSIF_API_SERVER_URL=http://lsif-server:3186'
       - 'GRAFANA_SERVER_URL=http://grafana:3000'
       - 'GITHUB_BASE_URL=http://github-proxy:3180'
     volumes:


### PR DESCRIPTION
We'll be phasing out LSIF_SERVER_URL for LSIF_API_SERVER_URL and can remove the old var once the tags are updated. See change in https://github.com/sourcegraph/sourcegraph/pull/9259.