### PR TITLE
Increase searcher max memory usage

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -209,7 +209,7 @@ services:
     container_name: searcher-0
     image: 'index.docker.io/sourcegraph/searcher:3.15.1@sha256:de5601ae6446c37b7f49adf3de8de25475c700a77f31dee8d28139fef0dc6584'
     cpus: 2
-    mem_limit: '2g'
+    mem_limit: '6g'
     environment:
       - GOMAXPROCS=2
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'


### PR DESCRIPTION
This is a proposed change, see https://sourcegraph.slack.com/archives/CJX299FGE/p1588960025377500 for more context.

2g is quite low for searcher on small/medium deployments, in the context of structural search/comby for large repos. Although comby does not itself perform super memory-intensive operations, it will load a repo zip file content into memory while searching, and 6g is a better mem limit. It will otherwise OOM.

Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:

There is no docker-compose/... folder in deploy-sourcegraph repo. I don't know if something is needed there.
