### PR TITLE
add prometheus server URL

### DIFF
--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -31,6 +31,7 @@ docker run --detach \
     -e PRECISE_CODE_INTEL_API_SERVER_URL=http://precise-code-intel-api-server:3186 \
     -e GRAFANA_SERVER_URL=http://grafana:3000 \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \
+    -e PROMETHEUS_URL=http://prometheus:9090 \
     -v $VOLUME:/mnt/cache \
     index.docker.io/sourcegraph/frontend:3.15.1@sha256:d6a2253ef0f1b40acb5a6dab7ea785302214c47ae27c4738ad1f9d67f8453ff8
 

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -32,7 +32,7 @@ docker run --detach \
     -e PRECISE_CODE_INTEL_API_SERVER_URL=http://precise-code-intel-api-server:3186 \
     -e GRAFANA_SERVER_URL=http://grafana:3370 \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \
-    -e PROMETHEUS_SERVER_URL=http://prometheus:9090 \
+    -e PROMETHEUS_URL=http://prometheus:9090 \
     -v $VOLUME:/mnt/cache \
     -p 0.0.0.0:$((3080 + $1)):3080 \
     index.docker.io/sourcegraph/frontend:3.15.1@sha256:d6a2253ef0f1b40acb5a6dab7ea785302214c47ae27c4738ad1f9d67f8453ff8

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -32,6 +32,7 @@ docker run --detach \
     -e PRECISE_CODE_INTEL_API_SERVER_URL=http://precise-code-intel-api-server:3186 \
     -e GRAFANA_SERVER_URL=http://grafana:3370 \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \
+    -e PROMETHEUS_SERVER_URL=http://prometheus:9090 \
     -v $VOLUME:/mnt/cache \
     -p 0.0.0.0:$((3080 + $1)):3080 \
     index.docker.io/sourcegraph/frontend:3.15.1@sha256:d6a2253ef0f1b40acb5a6dab7ea785302214c47ae27c4738ad1f9d67f8453ff8

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -87,6 +87,7 @@ services:
       - 'PRECISE_CODE_INTEL_API_SERVER_URL=http://precise-code-intel-api-server:3186'
       - 'GRAFANA_SERVER_URL=http://grafana:3370'
       - 'GITHUB_BASE_URL=http://github-proxy:3180'
+      - 'PROMETHEUS_SERVER_URL=http://prometheus:9090'
     healthcheck:
       test: "wget -q 'http://127.0.0.1:3080/healthz' -O /dev/null || exit 1"
       interval: 5s

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -87,7 +87,7 @@ services:
       - 'PRECISE_CODE_INTEL_API_SERVER_URL=http://precise-code-intel-api-server:3186'
       - 'GRAFANA_SERVER_URL=http://grafana:3370'
       - 'GITHUB_BASE_URL=http://github-proxy:3180'
-      - 'PROMETHEUS_SERVER_URL=http://prometheus:9090'
+      - 'PROMETHEUS_URL=http://prometheus:9090'
     healthcheck:
       test: "wget -q 'http://127.0.0.1:3080/healthz' -O /dev/null || exit 1"
       interval: 5s
@@ -125,6 +125,7 @@ services:
       - 'PRECISE_CODE_INTEL_API_SERVER_URL=http://precise-code-intel:3186'
       - 'GRAFANA_SERVER_URL=http://grafana:3000'
       - 'GITHUB_BASE_URL=http://github-proxy:3180'
+      - 'PROMETHEUS_URL=http://prometheus:9090'
     volumes:
       - 'sourcegraph-frontend-internal-0:/mnt/cache'
     networks:


### PR DESCRIPTION
for https://github.com/sourcegraph/sourcegraph/pull/10704 - adds `PROMETHEUS_SERVER_URL` to allow the frontend to query metrics.


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/697

<!-- add link or explanation of why it is not needed here -->
