### PR TITLE
pin cadvisor to sourcegraph mirror

### DIFF
--- a/deploy-cadvisor.sh
+++ b/deploy-cadvisor.sh
@@ -21,6 +21,6 @@ sudo docker run --detach \
     --volume=/sys:/sys:ro \
     --volume=/var/lib/docker/:/var/lib/docker:ro \
     --volume=/dev/disk/:/dev/disk:ro \
-    google/cadvisor:v0.33.0
+    index.docker.io/sourcegraph/cadvisor:insiders@sha256:4074c8bc608b78af3ca3d6e60b3794369a190ab2efd992e31b3079b075401efa
 
 echo "Deployed cadvisor"

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -466,7 +466,7 @@ services:
   #
   cadvisor:
     container_name: cadvisor
-    image: 'google/cadvisor:v0.33.0@sha256:47f1f8c02a3acfab77e74e2ec7acc0d475adc180ddff428503a4ce63f3d6061b'
+    image: 'index.docker.io/sourcegraph/cadvisor:insiders@sha256:4074c8bc608b78af3ca3d6e60b3794369a190ab2efd992e31b3079b075401efa'
     cpus: 1
     mem_limit: '1g'
     volumes:


### PR DESCRIPTION
https://github.com/sourcegraph/deploy-sourcegraph/pull/707#discussion_r429430670


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/707

<!-- add link or explanation of why it is not needed here -->
