### PR TITLE
set DEPLOY_TYPE for pure-docker, docker-compose

### DIFF
--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -18,6 +18,7 @@ docker run --detach \
     --restart=always \
     --cpus=4 \
     --memory=8g \
+    -e DEPLOY_TYPE='pure-docker' \
     -e GOMAXPROCS=4 \
     -e PGHOST=pgsql \
     -e SRC_GIT_SERVERS="$(addresses "gitserver-" $NUM_GITSERVER ":3178")" \

--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -18,7 +18,7 @@ docker run --detach \
     --restart=always \
     --cpus=4 \
     --memory=8g \
-    -e DEPLOY_TYPE='pure-docker' \
+    -e DEPLOY_TYPE=pure-docker \
     -e GOMAXPROCS=4 \
     -e PGHOST=pgsql \
     -e SRC_GIT_SERVERS="$(addresses "gitserver-" $NUM_GITSERVER ":3178")" \

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -18,6 +18,7 @@ docker run --detach \
     --restart=always \
     --cpus=4 \
     --memory=8g \
+    -e DEPLOY_TYPE='pure-docker' \
     -e GOMAXPROCS=12 \
     -e JAEGER_AGENT_HOST=jaeger \
     -e PGHOST=pgsql \

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -18,7 +18,7 @@ docker run --detach \
     --restart=always \
     --cpus=4 \
     --memory=8g \
-    -e DEPLOY_TYPE='pure-docker' \
+    -e DEPLOY_TYPE=pure-docker \
     -e GOMAXPROCS=12 \
     -e JAEGER_AGENT_HOST=jaeger \
     -e PGHOST=pgsql \

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -73,6 +73,7 @@ services:
     cpus: 4
     mem_limit: '8g'
     environment:
+      - DEPLOY_TYPE='docker-compose'
       - GOMAXPROCS=12
       - JAEGER_AGENT_HOST=jaeger
       - PGHOST=pgsql
@@ -112,6 +113,7 @@ services:
     cpus: 4
     mem_limit: '8g'
     environment:
+      - DEPLOY_TYPE='docker-compose'
       - GOMAXPROCS=4
       - PGHOST=pgsql
       - 'SRC_GIT_SERVERS=gitserver-0:3178'

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -73,7 +73,7 @@ services:
     cpus: 4
     mem_limit: '8g'
     environment:
-      - DEPLOY_TYPE='docker-compose'
+      - DEPLOY_TYPE=docker-compose
       - GOMAXPROCS=12
       - JAEGER_AGENT_HOST=jaeger
       - PGHOST=pgsql
@@ -113,7 +113,7 @@ services:
     cpus: 4
     mem_limit: '8g'
     environment:
-      - DEPLOY_TYPE='docker-compose'
+      - DEPLOY_TYPE=docker-compose
       - GOMAXPROCS=4
       - PGHOST=pgsql
       - 'SRC_GIT_SERVERS=gitserver-0:3178'


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/10399

Verified this works on both docker, docker-compose deployment types:

<img width="287" alt="Screen Shot 2020-05-29 at 3 21 48 PM" src="https://user-images.githubusercontent.com/23356519/83310295-5e883900-a1c0-11ea-9a8d-a208dc959d07.png"> <img width="251" alt="image" src="https://user-images.githubusercontent.com/23356519/83310373-ab6c0f80-a1c0-11ea-8cb4-379410d7ad02.png">

https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+.DeployType%28%29+-file:/*_test.go&patternType=literal - also doesn't look like any of the call points could cause issues with the new values

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: n/a, this is only for docker/docker-compose deployments

<!-- add link or explanation of why it is not needed here -->
