### PR TITLE
declare SRC_FRONTEND_INTERNAL for grafana

### DIFF
--- a/deploy-grafana.sh
+++ b/deploy-grafana.sh
@@ -21,6 +21,7 @@ docker run --detach \
     -v $VOLUME:/var/lib/grafana \
     -v $(pwd)/grafana/datasources:/sg_config_grafana/provisioning/datasources \
     -v $(pwd)/grafana/dashboards:/sg_grafana_additional_dashboards \
+    -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     index.docker.io/sourcegraph/grafana:3.16.0@sha256:771dd20ea85af7ba188022078f6937f035cab48f312929b8056831b0418b8cfe
 
 # Add the following lines above if you wish to use an auth proxy with Grafana:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -456,6 +456,8 @@ services:
       - 'grafana:/var/lib/grafana'
       - '../grafana/datasources:/sg_config_grafana/provisioning/datasources'
       - '../grafana/dashboards:/sg_grafana_additional_dashboards'
+    environment:
+      - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
     ports:
       - '0.0.0.0:3370:3370'
     networks:


### PR DESCRIPTION
for https://github.com/sourcegraph/sourcegraph/pull/11483


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: I don't believe this is needed there, since the default value of `sourcegraph-frontend-internal` is meant for k8s?

<!-- add link or explanation of why it is not needed here -->
