### PR TITLE
grafana: add jaeger datasource

### DIFF
--- a/grafana/datasources/datasources.yaml
+++ b/grafana/datasources/datasources.yaml
@@ -7,3 +7,8 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: false
+  - name: Jaeger
+    type: Jaeger
+    access: proxy
+    url: http://jaeger-query:16686/-/debug/jaeger
+    editable: false


### PR DESCRIPTION
depends on https://github.com/sourcegraph/sourcegraph/pull/11583

context: grafana 7 has built-in jaeger support

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/767

<!-- add link or explanation of why it is not needed here -->
