### PR TITLE
docker-compose: do not quote env var values

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -23,9 +23,9 @@ services:
     environment:
       - 'XDG_DATA_HOME=/caddy-storage/data'
       - 'XDG_CONFIG_HOME=/caddy-storage/config'
-      - 'SRC_FRONTEND_ADDRESSES="sourcegraph-frontend-0:3080"'
+      - 'SRC_FRONTEND_ADDRESSES=sourcegraph-frontend-0:3080'
       # Uncomment & update this line when using Let's Encrypt or custom HTTPS certificates:
-      # - 'SRC_SITE_ADDRESS="sourcegraph.example.com"'
+      # - 'SRC_SITE_ADDRESS=sourcegraph.example.com'
       #
       # Uncomment & update the following line when using HTTPS with Let's Encrypt
       # - 'SRC_ACME_EMAIL=admin@example.com'


### PR DESCRIPTION
The double quotes meant this Caddy configuration:

```
reverse_proxy {$SRC_FRONTEND_ADDRESSES}
```

Expanded to:

```
reverse_proxy "sourcegraph-frontend-0:3080 sourcegraph-frontend-1:3080 sourcegraph-frontend-2:3080"
```

Instead of:

```
reverse_proxy sourcegraph-frontend-0:3080 sourcegraph-frontend-1:3080 sourcegraph-frontend-2:3080
```

Which led to Sourcegraph being unavailable entirely:

```
2020/08/14 00:03:05.971	INFO	using provided configuration	{"config_file": "/etc/caddy/Caddyfile", "config_adapter": "caddyfile"}
run: adapting config using caddyfile: parsing caddyfile tokens for 'reverse_proxy': /etc/caddy/Caddyfile:7 - Error during parsing: parsing upstream address: parse "undefined://sourcegraph-frontend-0:3080 sourcegraph-frontend-1:3080 sourcegraph-frontend-2:3080": invalid character " " in host name
```

This came from





<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:

<!-- add link or explanation of why it is not needed here -->
