### PR TITLE
pure-docker test fixes

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,26 +7,26 @@ source ./replicas.sh
 docker network create sourcegraph &> /dev/null || true
 
 ./deploy-cadvisor.sh
-./deploy-github-proxy.sh &
-for i in $(seq 0 $(($NUM_GITSERVER - 1))); do (./deploy-gitserver.sh $i &); done
+./deploy-github-proxy.sh
+for i in $(seq 0 $(($NUM_GITSERVER - 1))); do (./deploy-gitserver.sh $i); done
 ./deploy-grafana.sh
 ./deploy-jaeger.sh
-./deploy-precise-code-intel-bundle-manager.sh &
-./deploy-precise-code-intel-worker.sh &
-./deploy-pgsql.sh &
+./deploy-precise-code-intel-bundle-manager.sh
+./deploy-precise-code-intel-worker.sh
+./deploy-pgsql.sh
 ./deploy-prometheus.sh
-./deploy-query-runner.sh &
-./deploy-redis-cache.sh &
-./deploy-redis-store.sh &
-./deploy-repo-updater.sh &
-for i in $(seq 0 $(($NUM_SEARCHER - 1))); do (./deploy-searcher.sh $i &); done
-for i in $(seq 0 $(($NUM_SYMBOLS - 1))); do (./deploy-symbols.sh $i &); done
-./deploy-syntect-server.sh &
-for i in $(seq 0 $(($NUM_INDEXED_SEARCH - 1))); do (./deploy-zoekt-indexserver.sh $i &); done
-for i in $(seq 0 $(($NUM_INDEXED_SEARCH - 1))); do (./deploy-zoekt-webserver.sh $i &); done
+./deploy-query-runner.sh
+./deploy-redis-cache.sh
+./deploy-redis-store.sh
+./deploy-repo-updater.sh
+for i in $(seq 0 $(($NUM_SEARCHER - 1))); do ./deploy-searcher.sh $i; done
+for i in $(seq 0 $(($NUM_SYMBOLS - 1))); do ./deploy-symbols.sh $i; done
+./deploy-syntect-server.sh
+for i in $(seq 0 $(($NUM_INDEXED_SEARCH - 1))); do ./deploy-zoekt-indexserver.sh $i; done
+for i in $(seq 0 $(($NUM_INDEXED_SEARCH - 1))); do ./deploy-zoekt-webserver.sh $i; done
 
 # Redis must be started before these.
 ./deploy-frontend-internal.sh
-for i in $(seq 0 $(($NUM_FRONTEND - 1))); do (./deploy-frontend.sh $i &); done
+for i in $(seq 0 $(($NUM_FRONTEND - 1))); do ./deploy-frontend.sh $i; done
 ./deploy-caddy.sh
 wait

--- a/test/pure-docker/Vagrantfile
+++ b/test/pure-docker/Vagrantfile
@@ -24,6 +24,9 @@ Vagrant.configure("2") do |config|
 
     apt-get update
 
+    # Configure nameserver to avoid some DNS failures.
+    echo nameserver 8.8.8.8 > /etc/resolv.conf
+
     # Install Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
     sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
@@ -33,20 +36,31 @@ Vagrant.configure("2") do |config|
 
     # Create volume directories.
     cd /deploy-sourcegraph-docker
+    echo
+    echo "creating deployment for volume directories"
+    echo
     ./deploy.sh
-    sleep 5
+    echo
+    echo "tearing down deployment for volume directories"
+    echo
     ./teardown.sh
 
     # Set permissions on volume directories.
     #
     # IMPORTANT: If these change, or a new service is introduced, it must be explicitly called out in
     # https://docs.sourcegraph.com/admin/updates/pure_docker similar to https://docs.sourcegraph.com/admin/updates/pure_docker#v3-12-5-v3-13-2-changes
+    echo
+    echo "forcing static permissions on volume directories"
+    echo
     pushd ~/sourcegraph-docker
     chown -R 100:101 gitserver* lsif-server* prometheus-v2* repo-updater* searcher* sourcegraph-frontend* symbols* zoekt*
     chown -R 999:1000 redis-store-disk redis-cache-disk
     chown -R 472:472 grafana-disk
     chown -R 999:999 pgsql-disk
     popd
+    echo
+    echo "creating deployment"
+    echo
     ./deploy.sh
   SHELL
 

--- a/test/pure-docker/smoke-test.sh
+++ b/test/pure-docker/smoke-test.sh
@@ -7,7 +7,7 @@ branch_or_tag=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-
 
 if [[ "$branch_or_tag" == *"customer-replica"* ]]; then
     # Expected number of containers on e.g. 3.18-customer-replica branch.
-    expect_containers="58"
+    expect_containers="59"
 else
     # Expected number of containers on `master` branch.
     expect_containers="23"


### PR DESCRIPTION
These fixes were needed to get the `3.18-customer-replica` (pure-docker) test branch passing.

These may also help https://github.com/sourcegraph/sourcegraph/issues/12996 but I haven't tested on the baremetal agents yet.