### PR TITLE
Vagrant suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,12 @@ vagrant plugin install vagrant-google
 gcloud auth application-default login
 ```
 
-- Execute the following where `ssh_user` is a user you have GCP metadata.
+- Configure your local variables using the following environment variables
+  - `VAGRANT_GCP_PROJECT_ID`: Project to run on. (default: `sourcegraph-server`)
+  - `VAGRANT_SSH_USER`: Your SSH user ID as specified in GCP metadata. (default: `ENV['USER']`)
+  - `VAGRANT_SSH_KEY`: Path to your SSH Keys as specified in GCP metadata. (default: `~/.ssh/id_rsa`)
 
+- Run the tests
 ```
 VAGRANT_SSH_USER=ssh_user vagrant up pure-docker-test --provider=google
 ```
@@ -108,16 +112,18 @@ This command will start a GCP instance, upload your local copy of the reposistor
 To run any additional tests or commands, edit the `servers.yaml` and add the commands to the `shell_commands` list, eg:
 ```
 shell_commands:
-    - { shell: 'moretests.sh'}
+    - [...]
+    - /vagrant/moretests.sh
+    - "ps aux | grep thisthat"
+    - |
+      cd /vagrant
+      bartest.sh
 ```
-
 
 To delete the server in GCP, execute the following command:
 ```
 vagrant destroy pure-docker-test
 ```
-
-
 
 ## Questions & Issues
 

--- a/test/pure-docker/Vagrantfile
+++ b/test/pure-docker/Vagrantfile
@@ -13,7 +13,7 @@ when 'CI'
     use_private_ip = true
     username = 'buildkite'
 else
-    project_id = 'sourcegraph-dev'
+    project_id = 'sourcegraph-server'
     use_private_ip = false
     username = ENV['VAGRANT_SSH_USER']
 end

--- a/test/pure-docker/Vagrantfile
+++ b/test/pure-docker/Vagrantfile
@@ -5,18 +5,6 @@ Vagrant.require_version '>= 1.6.0'
 VAGRANTFILE_API_VERSION = '2'.freeze
 # Require YAML module
 require 'yaml'
-# Setup for CI or Local
-case ENV['VAGRANT_RUN_ENV']
-when 'CI'
-    project_id = 'sourcegraph-ci'
-    external_ip = false
-    use_private_ip = true
-    username = 'buildkite'
-else
-    project_id = 'sourcegraph-server'
-    use_private_ip = false
-    username = ENV['VAGRANT_SSH_USER']
-end
 
 # Read YAML file with box details
 servers = YAML.load_file('servers.yaml')
@@ -29,31 +17,43 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       srv.vm.synced_folder '../../', '/deploy-sourcegraph-docker'
       srv.vm.boot_timeout = 600
 
+      # Setup for CI or Local
+      case ENV['VAGRANT_RUN_ENV']
+      when 'CI'
+        project_id = server['project_id']
+        external_ip = server['external_ip']
+        use_private_ip = server['use_private_ip']
+        username = server['username']
+        ssh_key_path = server['ssh_key_path']
+      else
+        project_id = ENV['VAGRANT_GCP_PROJECT_ID'] || 'sourcegraph-server'
+        external_ip = nil
+        use_private_ip = false
+        username = ENV['VAGRANT_SSH_USER'] || ENV['USER']
+        ssh_key_path = ENV['VAGRANT_SSH_KEY'] || '~/.ssh/id_rsa'
+      end
+
       srv.vm.provider :google do |g, o|
         g.machine_type = server['machine_type']
         g.image_family = 'ubuntu-1804-lts'
         g.google_project_id = project_id
         g.network = server['network']
-        g.subnetwork = server['subnetwork']
-        g.zone = 'us-central1-c'
         g.external_ip = external_ip
         g.use_private_ip = use_private_ip
         o.ssh.username = username
-        o.ssh.private_key_path = '~/.ssh/id_rsa'
+        o.ssh.private_key_path = ssh_key_path
       end
 
       srv.vm.provision 'shell', inline: <<-SHELL
-            #!/usr/bin/env bash
-            set -euxo pipefail
-            apt-get update
-            # Install Docker
-            curl -fsSL get.docker.com | sudo sh
-            cd /deploy-sourcegraph-docker && ./deploy.sh
-            /deploy-sourcegraph-docker/test/pure-docker/smoke-test.sh
+        #!/usr/bin/env bash
+        set -euxo pipefail
+        apt-get update
+        # Install Docker
+        curl -fsSL get.docker.com | sudo sh
       SHELL
 
       server['shell_commands'].each do |sh|
-        srv.vm.provision 'shell', inline: sh['shell']
+        srv.vm.provision 'shell', inline: sh
       end
     end
   end

--- a/test/pure-docker/servers.yaml
+++ b/test/pure-docker/servers.yaml
@@ -1,9 +1,15 @@
 ---
--
+- name: pure-docker-test
   box: google/gce
   machine_type: "custom-16-20480"
-  name: pure-docker-test
+  project_id: sourcegraph-ci
   external_ip: false
   use_private_ip: true
-  network: "default"
-  shell_commands: []
+  network: default
+  username: buildkite
+  ssh_key_path: "~/.ssh/id_rsa"
+  shell_commands:
+   - |
+      cd /deploy-sourcegraph-docker
+      ./deploy.sh
+   - "/deploy-sourcegraph-docker/test/pure-docker/smoke-test.sh"


### PR DESCRIPTION
I ran into a couple of issues when testing locally and ended up with this set of suggestions.

- Add more options to env-vars which can be easily added to .envrc locally
```
❯ cat .envrc
export VAGRANT_SSH_USER="foobar"
export VAGRANT_SSH_KEY="~/.ssh/google_compute_engine"
```
- Load all CI envs from files, so its not mixed. I was unsure about `machine_type` and `network` as they will likely not change
- Move user testing to our Auxiliary project
- Split base provisioning (left in the `Vagrantfile`) and test commands (in the `servers.yaml`)
- Set default ssh user to `ENV['USER']` which is what `gcloud beta compute ssh` uses and will probably match most users
