### PR TITLE
update docker compose docs to point to 3.20.1

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -9,7 +9,7 @@ Simply clone the repository and `docker-compose up -d` to deploy Sourcegraph:
 ```sh
 git clone https://github.com/sourcegraph/deploy-sourcegraph-docker
 cd deploy-sourcegraph-docker/docker-compose/
-git checkout v3.19.2
+git checkout v3.20.1
 docker-compose up -d
 ```
 


### PR DESCRIPTION



<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:

<!-- add link or explanation of why it is not needed here -->
