### PR TITLE
Ignore dhall files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ nginx/sourcegraph.key
 .vagrant
 *.log
 
- **/*.dhall 
+/right.dhall

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ nginx/sourcegraph.key
 .vagrant
 *.log
 
+ **/*.dhall 


### PR DESCRIPTION
Ignore dhall files for security reasons (see [security issue 8](https://github.com/sourcegraph/security-issues/issues/8))


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph/pull/1053) change:

<!-- add link or explanation of why it is not needed here -->
