### PR TITLE
Add MinIO deployment

### DIFF
--- a/deploy-minio.sh
+++ b/deploy-minio.sh
@@ -21,5 +21,5 @@ docker run --detach \
     -v $VOLUME:/data \
     -e MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE \
     -e MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
-    index.docker.io/sourcegraph/minio@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
+    index.docker.io/sourcegraph/minio@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f \
     server /data

--- a/deploy-minio.sh
+++ b/deploy-minio.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+# Description: MinIO for storing LSIF uploads.
+#
+# Disk: 128GB / persistent SSD
+# Network: 1Gbps
+# Liveness probe: HTTP GET http://minio:9000/minio/health/live
+# Ports exposed to other Sourcegraph services: 9000/TCP
+# Ports exposed to public internet: none
+#
+VOLUME="$HOME/sourcegraph-docker/minio-disk"
+./ensure-volume.sh $VOLUME 100
+docker run --detach \
+    --name=minio \
+    --network=sourcegraph \
+    --restart=always \
+    --cpus=1 \
+    --memory=1g \
+    -p 0.0.0.0:9000:9000 \
+    -v $VOLUME:/data \
+    -e MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE \
+    -e MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+    index.docker.io/sourcegraph/minio@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
+    server /data

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,6 +15,7 @@ for i in $(seq 0 $(($NUM_GITSERVER - 1))); do ./deploy-gitserver.sh $i; done
 ./deploy-precise-code-intel-worker.sh
 ./deploy-pgsql.sh
 ./deploy-codeintel-db.sh
+./deploy-minio.sh
 ./deploy-prometheus.sh
 ./deploy-query-runner.sh
 ./deploy-redis-cache.sh

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -535,6 +535,34 @@ services:
     networks:
       - sourcegraph
     restart: always
+  
+  # Description: MinIO for storing LSIF uploads.
+  #
+  # Disk: 128GB / persistent SSD
+  # Network: 1Gbps
+  # Ports exposed to other Sourcegraph services: 9000/TCP
+  # Ports exposed to public internet: none
+  #
+  minio:
+    container_name: minio
+    image: 'index.docker.io/sourcegraph/minio@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f'
+    cpus: 1
+    mem_limit: '1g'
+    environment:
+      - 'MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE'
+      - 'MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://127.0.0.1:9000/minio/health/live']
+      interval: 10s
+      timeout: 1s
+      retries: 3
+      start_period: 15s
+    volumes:
+      - 'minio:/data'
+    networks:
+      - sourcegraph
+    restart: always
+    command: ['server', '/data']
 
   # Description: Redis for storing short-lived caches.
   #
@@ -576,6 +604,7 @@ volumes:
   precise-code-intel-bundle-manager:
   pgsql:
   codeintel-db:
+  minio:
   prometheus-v2:
   redis-cache:
   redis-store:

--- a/teardown.sh
+++ b/teardown.sh
@@ -14,6 +14,7 @@ docker rm -f precise-code-intel-bundle-manager &> /dev/null || true
 docker rm -f precise-code-intel-worker &> /dev/null || true
 docker rm -f pgsql &> /dev/null || true &
 docker rm -f codeintel-db &> /dev/null || true &
+docker rm -f minio &> /dev/null || true &
 docker rm -f prometheus &> /dev/null || true
 docker rm -f query-runner &> /dev/null || true &
 docker rm -f redis-cache &> /dev/null || true &

--- a/test/docker-compose/smoke-test.sh
+++ b/test/docker-compose/smoke-test.sh
@@ -13,7 +13,7 @@ if [[ "$branch_or_tag" == *"customer-replica"* ]]; then
 	expect_containers="58"
 else
 	# Expected number of containers on `master` branch.
-	expect_containers="22"
+	expect_containers="23"
 fi
 
 echo "Giving containers 10s to start..."

--- a/test/docker-compose/smoke-test.sh
+++ b/test/docker-compose/smoke-test.sh
@@ -13,7 +13,7 @@ if [[ "$branch_or_tag" == *"customer-replica"* ]]; then
 	expect_containers="58"
 else
 	# Expected number of containers on `master` branch.
-	expect_containers="24"
+	expect_containers="23"
 fi
 
 echo "Giving containers 10s to start..."

--- a/test/docker-compose/smoke-test.sh
+++ b/test/docker-compose/smoke-test.sh
@@ -13,7 +13,7 @@ if [[ "$branch_or_tag" == *"customer-replica"* ]]; then
 	expect_containers="58"
 else
 	# Expected number of containers on `master` branch.
-	expect_containers="23"
+	expect_containers="24"
 fi
 
 echo "Giving containers 10s to start..."

--- a/test/pure-docker/smoke-test.sh
+++ b/test/pure-docker/smoke-test.sh
@@ -14,7 +14,7 @@ if [[ "$branch_or_tag" == *"customer-replica"* ]]; then
     expect_containers="58"
 else
     # Expected number of containers on `master` branch.
-    expect_containers="24"
+    expect_containers="23"
 fi
 
 echo "Giving containers 10s to start..."

--- a/test/pure-docker/smoke-test.sh
+++ b/test/pure-docker/smoke-test.sh
@@ -14,7 +14,7 @@ if [[ "$branch_or_tag" == *"customer-replica"* ]]; then
     expect_containers="58"
 else
     # Expected number of containers on `master` branch.
-    expect_containers="23"
+    expect_containers="25"
 fi
 
 echo "Giving containers 10s to start..."

--- a/test/pure-docker/volume-config.sh
+++ b/test/pure-docker/volume-config.sh
@@ -18,7 +18,7 @@ echo
 echo "forcing static permissions on volume directories"
 echo
 pushd ~/sourcegraph-docker
-chown -R 100:101 gitserver* lsif-server* prometheus-v2* repo-updater* searcher* sourcegraph-frontend* symbols* zoekt*
+chown -R 100:101 gitserver* lsif-server* prometheus-v2* repo-updater* searcher* sourcegraph-frontend* symbols* zoekt* minio-disk
 chown -R 999:1000 redis-store-disk redis-cache-disk
 chown -R 472:472 grafana-disk
 chown -R 999:999 pgsql-disk codeintel-db-disk


### PR DESCRIPTION
This adds a MinIO deployment. Part of https://github.com/sourcegraph/sourcegraph/issues/14825.

Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/1158
