### PR TITLE
releasing: remove manual updates

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -109,16 +109,6 @@ git tag v3.9.2
 git push origin v3.9.2
 ```
 
-### Update documentation & publish notifications
-
-Replace the old version with the new version in the `master` branches of the following:
-
-- This repository: `docker-compose/README.md`
-- sourcegraph/sourcegraph:
-    - replace two instances: https://github.com/sourcegraph/sourcegraph/blob/master/doc/admin/install/docker-compose/index.md
-    - add a new section with all relevant upgrade details: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a718276cbdc4c9e079d5495cb34ce663c5d35c01/-/blob/doc/admin/updates/docker_compose.md#updating-a-docker-compose-sourcegraph-instance
-    - Update `latestReleaseDockerComposeOrPureDocker` in https://github.com/sourcegraph/sourcegraph/blob/master/cmd/frontend/internal/app/pkg/updatecheck/handler.go#L47
-
 ## Releasing pure-docker
 
 For pure-docker, we provide customers with an exact diff of changes to make. They do not run our deploy.sh scripts directly, instead they copy them or adapt them to their own deployment environment entirely. This means we must carefully communicate each change that is made.


### PR DESCRIPTION
For the automation component + more details see https://github.com/sourcegraph/sourcegraph/pull/15521

Part of work that closes https://github.com/sourcegraph/sourcegraph/issues/15325

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: N/A, different release process there
* [ ] If this change is a new service, add this service to `tools/update-docker-tags.sh`
