### PR TITLE
releasing: tag is done by release tooling

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -101,6 +101,8 @@ This will take about ~10 minutes to run. Refer to the [testing documentation](TE
 
 ### Tag the final release
 
+> ⚠️ If you are using the Sourcegraph release tooling, this step will be done for you during `release:close`. Learn more about the release process in [the handbook](https://about.sourcegraph.com/handbook/engineering/releases).
+
 For example:
 
 ```


### PR DESCRIPTION
This feature was added in https://github.com/sourcegraph/sourcegraph/pull/15743, closes https://github.com/sourcegraph/sourcegraph/issues/15323

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] If this change is a new service, add this service to `tools/update-docker-tags.sh`
