### PR TITLE
Increase expected containers to 59

### DIFF
--- a/test/pure-docker/smoke-test.sh
+++ b/test/pure-docker/smoke-test.sh
@@ -11,7 +11,7 @@ branch_or_tag=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-
 
 if [[ "$branch_or_tag" == *"customer-replica"* ]]; then
     # Expected number of containers on e.g. 3.18-customer-replica branch.
-    expect_containers="58"
+    expect_containers="59"
 else
     # Expected number of containers on `master` branch.
     expect_containers="24"


### PR DESCRIPTION
Testing this I found there are actually 59 containers.
```
    pure-docker-test: sourcegraph-frontend-2
    pure-docker-test: sourcegraph-frontend-1
    pure-docker-test: sourcegraph-frontend-0
    pure-docker-test: sourcegraph-frontend-internal
    pure-docker-test: zoekt-webserver-0
    pure-docker-test: zoekt-indexserver-0
    pure-docker-test: syntect-server
    pure-docker-test: symbols-3
    pure-docker-test: symbols-2
    pure-docker-test: symbols-1
    pure-docker-test: symbols-0
    pure-docker-test: searcher-15
    pure-docker-test: searcher-14
    pure-docker-test: searcher-13
    pure-docker-test: searcher-12
    pure-docker-test: searcher-11
    pure-docker-test: searcher-10
    pure-docker-test: searcher-9
    pure-docker-test: searcher-8
    pure-docker-test: searcher-7
    pure-docker-test: searcher-6
    pure-docker-test: searcher-5
    pure-docker-test: searcher-4
    pure-docker-test: searcher-3
    pure-docker-test: searcher-2
    pure-docker-test: searcher-1
    pure-docker-test: searcher-0
    pure-docker-test: repo-updater
    pure-docker-test: redis-store
    pure-docker-test: redis-cache
    pure-docker-test: query-runner
    pure-docker-test: prometheus
    pure-docker-test: minio
    pure-docker-test: codeintel-db
    pure-docker-test: pgsql
    pure-docker-test: precise-code-intel-worker
    pure-docker-test: jaeger
    pure-docker-test: grafana
    pure-docker-test: gitserver-17
    pure-docker-test: gitserver-16
    pure-docker-test: gitserver-15
    pure-docker-test: gitserver-14
    pure-docker-test: gitserver-13
    pure-docker-test: gitserver-12
    pure-docker-test: gitserver-11
    pure-docker-test: gitserver-10
    pure-docker-test: gitserver-9
    pure-docker-test: gitserver-8
    pure-docker-test: gitserver-7
    pure-docker-test: gitserver-6
    pure-docker-test: gitserver-5
    pure-docker-test: gitserver-4
    pure-docker-test: gitserver-3
    pure-docker-test: gitserver-2
    pure-docker-test: gitserver-1
    pure-docker-test: gitserver-0
    pure-docker-test: github-proxy
    pure-docker-test: cadvisor
    pure-docker-test: apache
```
We must have missed a change to this number at some point.