### PR TITLE
remove lsif volume

### DIFF
--- a/test/pure-docker/volume-config.sh
+++ b/test/pure-docker/volume-config.sh
@@ -18,7 +18,7 @@ echo
 echo "forcing static permissions on volume directories"
 echo
 pushd ~/sourcegraph-docker
-chown -R 100:101 gitserver* lsif-server* prometheus-v2* repo-updater* searcher* sourcegraph-frontend* symbols* zoekt* minio-disk
+chown -R 100:101 gitserver* prometheus-v2* repo-updater* searcher* sourcegraph-frontend* symbols* zoekt* minio-disk
 chown -R 999:1000 redis-store-disk redis-cache-disk
 chown -R 472:472 grafana-disk
 chown -R 999:999 pgsql-disk codeintel-db-disk


### PR DESCRIPTION
fixes error `pure-docker-test: chown: cannot access 'lsif-server*'`
