### PR TITLE
qa: fix branch logic for buildkite

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -8,9 +8,12 @@ exit_code=0
 
 cd test/
 
-if ! vagrant plugin list --no-tty | grep vagrant-google; then
-	vagrant plugin install vagrant-google
-fi
+plugins=(vagrant-google vagrant-env vagrant-scp)
+for i in "${plugins[@]}"; do
+  if ! vagrant plugin list --no-tty | grep "$i"; then
+    vagrant plugin install "$i"
+  fi
+done
 
 vagrant up $box --provider=google || exit_code=$?
 vagrant destroy -f $box

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -12,6 +12,7 @@ servers = YAML.load_file('servers.yaml')
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Iterate through entries in YAML file
   servers.each do |server|
+    config.env.enable
     config.vm.define server['name'] do |srv|
       srv.vm.box = server['box']
       srv.vm.synced_folder '../', '/deploy-sourcegraph-docker'
@@ -47,7 +48,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       srv.vm.provision 'shell', inline: <<-SHELL
-      SHELL
+        #!/usr/bin/env bash
+        cat << EOF >> /root/.profile
+export GIT_BRANCH=#{ENV['BUILDKITE_BRANCH']}
+EOF      
+        SHELL
 
       server['shell_commands'].each do |sh|
         srv.vm.provision 'shell', inline: sh

--- a/test/docker-compose/smoke-test.sh
+++ b/test/docker-compose/smoke-test.sh
@@ -6,9 +6,7 @@ sudo su
 
 docker-compose up -d
 
-branch_or_tag=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match || echo '')
-
-if [[ "$branch_or_tag" == *"customer-replica"* ]]; then
+if [[ "$GIT_BRANCH" == *"customer-replica"* ]]; then
 	# Expected number of containers on e.g. 3.18-customer-replica branch.
 	expect_containers="58"
 else

--- a/test/pure-docker/smoke-test.sh
+++ b/test/pure-docker/smoke-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eufo pipefail
+set -eufxo pipefail
 
 cd /deploy-sourcegraph-docker
 sudo su
@@ -7,9 +7,7 @@ sudo su
 #Deploy sourcegraph
 ./deploy.sh
 
-branch_or_tag=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match || echo '')
-
-if [[ "$branch_or_tag" == *"customer-replica"* ]]; then
+if [[ "$GIT_BRANCH" == *"customer-replica"* ]]; then
     # Expected number of containers on e.g. 3.18-customer-replica branch.
     expect_containers="59"
 else


### PR DESCRIPTION
repos are in detached head mode in buildkite. This leverages the BK environment variable to get the info we need to differentiate between a regular branch or customer replica to test appropriately
