### PR TITLE
tools: generate update-docker-tags args from sourcegraph/sourcegraph

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,4 @@
   this repository. If uneeded, add link or explanation of why it is not needed here.
 -->
 * [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
-* [ ] If this change introduces or removes a service, add this service to `tools/update-docker-tags.sh`
 * [ ] All images have a valid tag and SHA256 sum

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,30 @@
+# based on https://github.com/pascalgn/automerge-action/tree/v0.9.0#usage
+name: Automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: pascalgn/automerge-action@v0.12.0
+        env:
+          # Allows this merge to trigger other actions
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_METHOD: squash

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/sourcegraph/deploy-sourcegraph-docker
 
 go 1.15
 
-require github.com/slimsag/update-docker-tags v0.7.0
+require (
+    github.com/slimsag/update-docker-tags v0.7.0
+	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201129044102-91280e756de5
+)

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,4 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/slimsag/update-docker-tags v0.7.0 h1:43SSOii74DpuQ3HK+AxHeE54tTFiUEz1xOsiI8hwymQ=
 github.com/slimsag/update-docker-tags v0.7.0/go.mod h1:T42NkUDP2MrfiSj3NT4JI27g/ksCngfCiY1goUQdIh0=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201129044102-91280e756de5/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,11 @@
       "ignoreUnstable": false,
       "semanticCommits": false,
       "automerge": false
+    },
+    {
+      "groupName": "Sourcegraph Docker images list",
+      "packagePatterns": ["github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"],
+      "labels": ["automerge"]
     }
   ],
   "masterIssue": true,

--- a/tools/enforce-tags/main.go
+++ b/tools/enforce-tags/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		log.Fatal("constraint, directory arguments must be provided")
+	}
+	var (
+		constraint = os.Args[1]
+		dir        = os.Args[2]
+	)
+	args := []string{
+		"run",
+		"github.com/slimsag/update-docker-tags",
+	}
+	for _, image := range images.SourcegraphDockerImages {
+		args = append(args, fmt.Sprintf("-enforce=sourcegraph/%s=%s", image, constraint))
+	}
+	args = append(args, dir)
+	log.Println(strings.Join(args, " "))
+
+	cmd := exec.Command("go", args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	if err := cmd.Run(); err != nil {
+		log.Fatal((err))
+	}
+}

--- a/tools/update-docker-tags.sh
+++ b/tools/update-docker-tags.sh
@@ -1,28 +1,10 @@
 #!/bin/bash
 
+set -e
+
+root_dir="$(dirname "${BASH_SOURCE[0]}")/.."
+cd "$root_dir"
+
 CONSTRAINT=$1
 
-# Using `go run` ensures we are using the version of `update-docker-tags` pinned in `go.mod`
-go run github.com/slimsag/update-docker-tags \
-  -enforce="sourcegraph/cadvisor=$CONSTRAINT" \
-  -enforce="sourcegraph/frontend=$CONSTRAINT" \
-  -enforce="sourcegraph/jaeger-agent=$CONSTRAINT" \
-  -enforce="sourcegraph/github-proxy=$CONSTRAINT" \
-  -enforce="sourcegraph/gitserver=$CONSTRAINT" \
-  -enforce="sourcegraph/grafana=$CONSTRAINT" \
-  -enforce="sourcegraph/indexed-searcher=$CONSTRAINT" \
-  -enforce="sourcegraph/search-indexer=$CONSTRAINT" \
-  -enforce="sourcegraph/jaeger-all-in-one=$CONSTRAINT" \
-  -enforce="sourcegraph/postgres-11.4=$CONSTRAINT" \
-  -enforce="sourcegraph/precise-code-intel-worker=$CONSTRAINT" \
-  -enforce="sourcegraph/codeintel-db=$CONSTRAINT" \
-  -enforce="sourcegraph/syntax-highlighter=$CONSTRAINT" \
-  -enforce="sourcegraph/prometheus=$CONSTRAINT" \
-  -enforce="sourcegraph/query-runner=$CONSTRAINT" \
-  -enforce="sourcegraph/redis-cache=$CONSTRAINT" \
-  -enforce="sourcegraph/redis-store=$CONSTRAINT" \
-  -enforce="sourcegraph/repo-updater=$CONSTRAINT" \
-  -enforce="sourcegraph/searcher=$CONSTRAINT" \
-  -enforce="sourcegraph/symbols=$CONSTRAINT" \
-  -enforce="sourcegraph/minio=$CONSTRAINT" \
-  ./
+go run ./tools/enforce-tags "$CONSTRAINT" base/


### PR DESCRIPTION
<!-- description here -->

Closes https://github.com/sourcegraph/sourcegraph/issues/15896 , mirrors https://github.com/sourcegraph/deploy-sourcegraph/pull/1382

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/1382
* [x] All images have a valid tag and SHA256 sum
