### PR TITLE
Add self-destroy permissions to tests

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,6 +1,6 @@
 $schema: 'http://json.schemastore.org/buildkite'
 env:
-  IMAGE: 'e2e-491e9f27-2020-10-28t17-32-00z'
+  IMAGE: 'e2e-cd59179f-2020-12-04t18-24-14z'
   VAGRANT_RUN_ENV: 'CI'
 steps:
   - label: ':docker:'

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -44,6 +44,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         g.network = server['network']
         g.external_ip = external_ip
         g.use_private_ip = use_private_ip
+        g.scopes = [
+            "compute-rw"
+        ]
         o.ssh.username = username
         o.ssh.private_key_path = ssh_key_path
       end


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/17020

We found some `docker-test-*` images that were not being destroyed by
the `self-destroy`. This is because the images were missing the required
`scope` that allowes them to perofrm the destroy call.

This also updates the image to be in-sync with `sourcegraph/sourcegraph`