### PR TITLE
update release guide

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,7 +69,7 @@ For pure-docker, we provide customers with an exact diff of changes to make. The
 
 To reduce the chance for errors, we send an exact diff of changes. This diff needs to be as minimal and concise as possible, and e.g. not include changes to unrelated files like `.prettierignore` or `docker-compose/` to avoid any confusion. See https://docs.sourcegraph.com/admin/updates/pure_docker for examples of what these diffs look like.
 
-Pretend `3.8` was the last version of pure-docker release (look for the latest `n.n-customer-replica` branch), and that `3.9` is the version we want to release (which must have already been released for Docker Compose deployments). Then:
+Pretend `3.8` was the last version of pure-docker release (look for the latest `n.n-customer-replica` branch), and that `3.9` is the version we want to release. Then:
 
 ```sh
 # Checkout the current pure-docker release branch

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,39 +49,7 @@ Refer to the [testing documentation](TESTING.md) for running tests from your loc
 
 > ⚠️ This test now runs in Buildktie, in the `qa` pipeline under the `Sourcegraph Upgrade` step, you can validate [the results of the CI run](https://buildkite.com/sourcegraph)
 
-**IMPORTANT**: This step MUST be run on a Linux machine, NOT Mac or Windows/WSL. This is because Docker for Linux treats file permissions differently and we must identify such issues.
-
-Start the prior version of Docker Compose:
-
-```
-git checkout <previous_version_branch>
-cd docker-compose/
-docker-compose up -d
-```
-
-Check that all services come up and report as healthy in the output of:
-
-```
-docker ps
-```
-
-Visit http://localhost and confirm the app loads.
-
-Upgrade to the latest version:
-
-```
-docker-compose down
-git checkout master
-docker-compose up -d
-```
-
-Check that all services come up and report as healthy in the output of:
-
-```
-docker ps
-```
-
-Visit http://localhost and confirm the app loads.
+Refer to the [testing documentation](TESTING.md) for running tests from your local machine.
 
 ### Tag the final release
 
@@ -110,8 +78,8 @@ git checkout 3.8-customer-replica
 # Create the new pure-docker release branch
 git checkout -B 3.9-customer-replica 
 
-# Merge the 3.9 branch into the pure-docker release branch.
-git merge 3.9
+# Merge the publish-3.9 branch, which will have been created by the release tool, into the pure-docker release branch.
+git merge publish-3.9
 
 # Show which files may have been deleted, etc.
 git status
@@ -124,31 +92,35 @@ At this point you should evaluate the `git status` output as well as all the cha
 
 1. Files that were shown as deleted in the `git status` output get deleted in the relevant commit.
 2. Create **one** commit with changes _unrelated to the upgrade_, i.e. include ALL changes that are not directly related to upgrading:
-    - `git commit -m 'merge 3.8 (changes unrelated to upgrade)'`
+    - `git commit -m 'merge 3.9 (changes unrelated to upgrade)'`
 3. Create **one** commit with the changes _customers need to apply in order to ugprade_, i.e. the image tag changes, adding/removing any new services, updating env vars, but no unrelated changes.
     - Do not include `docker-compose/` changes in this commit, those are irrelevant to pure-docker users.
-    - `git commit -m 'upgrade to v3.8.2'`
+    - `git commit -m 'upgrade to v3.9.0'`
 
 During this process you will run into two merge conflicts:
 
 - Do not commit: `deploy-caddy.sh` or changes related to it, as `deploy-apache.sh` is used here.
 - Do not commit: changes to `deploy-pgsql.sh`, as Postgres 9.6 is used here.
 
+4. Push the changes to github
+```shell
+git push --set-upstream origin 3.9-customer-replica
+```
+
 Check buildkite for the branch after pushing it, e.g. at https://github.com/sourcegraph/deploy-sourcegraph-docker/commits/3.19-customer-replica
 
 This will take about ~10 minutes to run. Refer to the [testing documentation](TESTING.md) if you run into issues / need more instructions.
 
-Once you see `ALL TESTS PASSED`, then push the new pure-docker release branch up and tag the release:
+Once you see `ALL TESTS PASSED`, tag the release:
 
 ```sh
-git push --set-upstream origin 3.8-customer-replica
-git tag customer-replica-v3.8.2
-git push origin customer-replica-v3.8.2
+git tag customer-replica-v3.9.0
+git push origin customer-replica-v3.9.0
 ```
 
 Write an entry for https://docs.sourcegraph.com/admin/updates/pure_docker which includes:
 
-- A link to your `upgrade to v3.8.2` commit describing the exact changes needed to be made.
+- A link to your `upgrade to v3.9.0` commit describing the exact changes needed to be made.
 - Any specific manual migrations, including potential `chown` commands that may be needed (if any new service is introduced, etc.)
 - Look at https://github.com/sourcegraph/sourcegraph/pulls?q=is%3Apr+is%3Aopen+pure-docker to see if there are any open PRs that might need to be included.
 


### PR DESCRIPTION
Fixes the version numbers in the pure-docker release which I think were misleading
Removes duplicate compose smoke test instructions which are now in TESTING.md
Instructs the release captain to create to merge the publish branch into customer replica, thus the last step of releasing docker is to close the PR eg: #196  created by the release tool