### PR TITLE
Replace cpu limits with shares

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
   caddy:
     container_name: caddy
     image: 'index.docker.io/caddy/caddy:alpine@sha256:ef2f47730caa12cb7d0ba944c048b8e48f029d5e0ff861840fa2b8f1868e1966'
-    cpus: 4
+    cpus: 4096
     mem_limit: '4g'
     environment:
       - 'XDG_DATA_HOME=/caddy-storage/data'
@@ -70,7 +70,7 @@ services:
   sourcegraph-frontend-0:
     container_name: sourcegraph-frontend-0
     image: 'index.docker.io/sourcegraph/frontend:insiders@sha256:3a77ddb36fb8723d1b81ba422589a5008480f0c99f5f43b447d1e659bb8e915a'
-    cpus: 4
+    cpus: 4096
     mem_limit: '8g'
     environment:
       - DEPLOY_TYPE=docker-compose
@@ -110,7 +110,7 @@ services:
   sourcegraph-frontend-internal:
     container_name: sourcegraph-frontend-internal
     image: 'index.docker.io/sourcegraph/frontend:insiders@sha256:3a77ddb36fb8723d1b81ba422589a5008480f0c99f5f43b447d1e659bb8e915a'
-    cpus: 4
+    cpus: 4096
     mem_limit: '8g'
     environment:
       - DEPLOY_TYPE=docker-compose
@@ -143,7 +143,7 @@ services:
   gitserver-0:
     container_name: gitserver-0
     image: 'index.docker.io/sourcegraph/gitserver:insiders@sha256:e8ecdc23c106845f37806b40eb762bc9e2f93d6d30a112e5a1ba6c2e46e58ba4'
-    cpus: 4
+    cpus: 4096
     mem_limit: '8g'
     environment:
       - GOMAXPROCS=4
@@ -186,7 +186,7 @@ services:
   zoekt-webserver-0:
     container_name: zoekt-webserver-0
     image: 'index.docker.io/sourcegraph/indexed-searcher:insiders@sha256:c9d0a3488f3a6030153004c3f0e306c540290c3a5ebd33914be1931f9428485b'
-    cpus: 8
+    cpus: 8192
     mem_limit: '50g'
     environment:
       - GOMAXPROCS=8
@@ -212,7 +212,7 @@ services:
   searcher-0:
     container_name: searcher-0
     image: 'index.docker.io/sourcegraph/searcher:insiders@sha256:6d5dd3c48a6c13fc554422fb24cc5bb6f30aa833e34bd90b6dd5558736095eab'
-    cpus: 2
+    cpus: 2048
     mem_limit: '2g'
     environment:
       - GOMAXPROCS=2
@@ -240,7 +240,7 @@ services:
   github-proxy:
     container_name: github-proxy
     image: 'index.docker.io/sourcegraph/github-proxy:insiders@sha256:8e6c84ba2fb7c1cb03bba5ad0e15d3a655f9e13742e0ffa769391a271f02c562'
-    cpus: 1
+    cpus: 1024
     mem_limit: '1g'
     environment:
       - GOMAXPROCS=1
@@ -258,7 +258,7 @@ services:
   precise-code-intel-worker:
     container_name: precise-code-intel-worker
     image: 'index.docker.io/sourcegraph/precise-code-intel-worker:insiders@sha256:b635e06165d1e6a4ca7573f7aa97baba7e392d88b83d7cee8752928202db94a1'
-    cpus: 2
+    cpus: 2048
     mem_limit: '4g'
     environment:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
@@ -283,7 +283,7 @@ services:
   query-runner:
     container_name: query-runner
     image: 'index.docker.io/sourcegraph/query-runner:insiders@sha256:78e8be0ed502eafd08b00ffbb693951a02743906bd63e17401b0b16e29d383d8'
-    cpus: 1
+    cpus: 1024
     mem_limit: '1g'
     environment:
       - GOMAXPROCS=1
@@ -302,7 +302,7 @@ services:
   repo-updater:
     container_name: repo-updater
     image: 'index.docker.io/sourcegraph/repo-updater:insiders@sha256:53f0fcd28885d379c1c9046028e45ae2b96be4a34a0011afacb133d76bc82bb6'
-    cpus: 4
+    cpus: 4096
     mem_limit: '4g'
     environment:
       - GOMAXPROCS=1
@@ -324,7 +324,7 @@ services:
   syntect-server:
     container_name: syntect-server
     image: 'index.docker.io/sourcegraph/syntax-highlighter:insiders@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de'
-    cpus: 4
+    cpus: 4096
     mem_limit: '6g'
     healthcheck:
       test: "wget -q 'http://127.0.0.1:9238/health' -O /dev/null || exit 1"
@@ -345,7 +345,7 @@ services:
   symbols-0:
     container_name: symbols-0
     image: 'index.docker.io/sourcegraph/symbols:insiders@sha256:566c40dd67bf7c61a27bce485daf78a2373cfb99633bfaf1714f54f18e947bf3'
-    cpus: 2
+    cpus: 2048
     mem_limit: '4g'
     environment:
       - GOMAXPROCS=2
@@ -372,7 +372,7 @@ services:
   prometheus:
     container_name: prometheus
     image: 'index.docker.io/sourcegraph/prometheus:insiders@sha256:dc0a8dd404f43e7d2f8b664c3b6f5a448c62476526ff47a0fc3500c93aff0ba0'
-    cpus: 4
+    cpus: 4096
     mem_limit: '8g'
     volumes:
       - 'prometheus-v2:/prometheus'
@@ -399,7 +399,7 @@ services:
   grafana:
     container_name: grafana
     image: 'index.docker.io/sourcegraph/grafana:insiders@sha256:9ea6958ed176855ec33a5a3cc632eae257fd227fa3de1f987d96bf05c7e83d66'
-    cpus: 1
+    cpus: 1024
     mem_limit: '1g'
     volumes:
       - 'grafana:/var/lib/grafana'
@@ -420,7 +420,7 @@ services:
   cadvisor:
     container_name: cadvisor
     image: 'index.docker.io/sourcegraph/cadvisor:insiders@sha256:90179250038aa47222dc9cea2cf8a9b1b35c3adb01a4bf42fc87b14963c01e91'
-    cpus: 1
+    cpus: 1024
     mem_limit: '1g'
     volumes:
       - '/:/rootfs:ro'
@@ -445,7 +445,7 @@ services:
   jaeger:
     container_name: jaeger
     image: 'index.docker.io/sourcegraph/jaeger-all-in-one:insiders@sha256:1fe9064eadb29dd7d6be754ae831708ba248eb4c907e8bf639dac1d23e8cd3b7'
-    cpus: 0.5
+    cpus: 512
     mem_limit: '512m'
     ports:
       # Query port
@@ -470,7 +470,7 @@ services:
   pgsql:
     container_name: pgsql
     image: 'index.docker.io/sourcegraph/postgres-11.4:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97'
-    cpus: 4
+    cpus: 4096
     mem_limit: '2g'
     healthcheck:
       test: '/liveness.sh'
@@ -494,7 +494,7 @@ services:
   codeintel-db:
     container_name: codeintel-db
     image: 'index.docker.io/sourcegraph/codeintel-db:insiders@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad'
-    cpus: 4
+    cpus: 4096
     mem_limit: '2g'
     healthcheck:
       test: '/liveness.sh'
@@ -507,7 +507,7 @@ services:
     networks:
       - sourcegraph
     restart: always
-  
+
   # Description: MinIO for storing LSIF uploads.
   #
   # Disk: 128GB / persistent SSD
@@ -518,7 +518,7 @@ services:
   minio:
     container_name: minio
     image: 'index.docker.io/sourcegraph/minio:insiders@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f'
-    cpus: 1
+    cpus: 1024
     mem_limit: '1g'
     environment:
       - 'MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE'
@@ -545,7 +545,7 @@ services:
   redis-cache:
     container_name: redis-cache
     image: 'index.docker.io/sourcegraph/redis-cache:insiders@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56'
-    cpus: 1
+    cpus: 1024
     mem_limit: '6g'
     volumes:
       - 'redis-cache:/redis-data'
@@ -561,7 +561,7 @@ services:
   redis-store:
     container_name: redis-store
     image: 'index.docker.io/sourcegraph/redis-store:insiders@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168'
-    cpus: 1
+    cpus: 1024
     mem_limit: '6g'
     volumes:
       - 'redis-store:/redis-data'

--- a/docker-compose/pgsql-only-migrate.docker-compose.yaml
+++ b/docker-compose/pgsql-only-migrate.docker-compose.yaml
@@ -13,7 +13,7 @@ services:
   pgsql:
     container_name: pgsql
     image: 'index.docker.io/sourcegraph/postgres-11.4:3.21.2@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97'
-    cpus: 4
+    cpus: 4096
     mem_limit: '2g'
     healthcheck:
       test: '/liveness.sh'


### PR DESCRIPTION
In most systems we want to ensure each container gets a 'fair' amount
of CPU relative to the other resources given we have a dedicated
host.

This uses CPU shares to define the weight an the minimum reserved memory
for each service, but allows services to expand beyond that capacity unless
the system is constrained.

## TODO:

- [ ] Add a note in our doc that we expect `docker-compose` hosts to be dedicated or limits must be added by the customer in which `1024 == 1 cpu` generally.