### PR TITLE
cadvisor: add commented support for macos

### DIFF
--- a/deploy-cadvisor.sh
+++ b/deploy-cadvisor.sh
@@ -10,6 +10,9 @@ source ./replicas.sh
 # Ports exposed to other Sourcegraph services: 8080/TCP
 # Ports exposed to the public internet: none
 #
+# Also add the following volume mount for container monitoring on MacOS:
+#   --volume='/var/run/docker.sock:/var/run/docker.sock:ro' 
+#
 sudo docker run --detach \
     --name=cadvisor \
     --network=sourcegraph \

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -428,6 +428,8 @@ services:
       - '/sys:/sys:ro'
       - '/var/lib/docker/:/var/lib/docker:ro'
       - '/dev/disk/:/dev/disk:ro'
+      # Uncomment to enable container monitoring on MacOS
+      # - '/var/run/docker.sock:/var/run/docker.sock:ro'
     networks:
       - sourcegraph
     restart: always
@@ -507,7 +509,7 @@ services:
     networks:
       - sourcegraph
     restart: always
-  
+
   # Description: MinIO for storing LSIF uploads.
   #
   # Disk: 128GB / persistent SSD


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/17072, see https://github.com/sourcegraph/sourcegraph/issues/17072#issuecomment-757460360

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
