### PR TITLE
prometheus job label

### DIFF
--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -7,16 +7,48 @@
     #- codeintel-db:9187
     #- redis-cache:9121
     #- redis-store:9121
+- labels:
+    job: node
+  targets:
     - cadvisor:8080
-    - sourcegraph-frontend-internal:6060
+- labels:
+    job: github-proxy
+  targets:
     - github-proxy:6060
+- labels:
+    job: query-runner
+  targets:
     - query-runner:6060
+- labels:
+    job: repo-updater
+  targets:
     - repo-updater:6060
+- labels:
+    job: node
+  targets:
     - syntect-server:6060
+- labels:
+    job: precise-code-intel-worker
+  targets:
     - precise-code-intel-worker:6060
     # Add new entries here for every searcher/symbol/gitserver replica.
+- labels:
+    job: zoekt-indexserver
+  targets:
     - zoekt-indexserver-0:6072
+- labels:
+    job: sourcegraph-frontend
+  targets:
     - sourcegraph-frontend-0:6060
+- labels:
+    job: gitserver
+  targets:
     - gitserver-0:6060
+- labels:
+    job: searcher
+  targets:
     - searcher-0:6060
+- labels:
+    job: symbols
+  targets:
     - symbols-0:6060

--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -11,6 +11,7 @@
     job: node
   targets:
     - cadvisor:8080
+    - sourcegraph-frontend-internal:6060
 - labels:
     job: github-proxy
   targets:


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/16552 for docker compose, pure docker.

I'm not clear what the previous value achieved. No rewrite rules kicked in and the label value in a live environment is "node" for all the containers and services. Don't think that's too useful. I left a couple as "node" where I couldn't find k8s or single server counterparts.