### PR TITLE
migrate single server to compose

### DIFF
--- a/docker-compose/db-only-migrate.docker-compose.yaml
+++ b/docker-compose/db-only-migrate.docker-compose.yaml
@@ -12,7 +12,7 @@ services:
   #
   pgsql:
     container_name: pgsql
-    image: 'index.docker.io/sourcegraph/postgres-11.4:3.21.2@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97'
+    image: 'index.docker.io/sourcegraph/postgres-11.4:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97'
     cpus: 4
     mem_limit: '2g'
     healthcheck:
@@ -46,6 +46,6 @@ services:
 
 volumes:
   pgsql:
-  codeintel-db
+  codeintel-db:
 networks:
-  sourcegraph:    
+  sourcegraph:

--- a/docker-compose/db-only-migrate.docker-compose.yaml
+++ b/docker-compose/db-only-migrate.docker-compose.yaml
@@ -26,7 +26,26 @@ services:
     networks:
       - sourcegraph
     restart: always
+
+  codeintel-db:
+    container_name: codeintel-db
+    image: 'index.docker.io/sourcegraph/codeintel-db:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97'
+    cpus: 4
+    mem_limit: '2g'
+    healthcheck:
+      test: '/liveness.sh'
+      interval: 10s
+      timeout: 1s
+      retries: 3
+      start_period: 15s
+    volumes:
+      - 'codeintel-db:/data/'
+    networks:
+      - sourcegraph
+    restart: always
+
 volumes:
   pgsql:
+  codeintel-db
 networks:
-  sourcegraph:
+  sourcegraph:    

--- a/tools/migrate.sh
+++ b/tools/migrate.sh
@@ -1,39 +1,53 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -uxo pipefail
 
 # shellcheck source=migration_vars
 source migration_vars
 
 IMAGE=${IMAGE:-sourcegraph/server}
-# trap 'rm -f ./*pg.out' EXIT
+sg_dump_file=$(mktemp)
+codeintel_dump_file=$(mktemp)
 
+trap 'rm -f ${sg_dump_file} ${codeintel_dump_file}' EXIT
+
+# Get the  ID of the sourcegraph container
 CONTAINER_ID=$(ssh "${SRC_HOST}" docker ps | grep "${IMAGE}:${VERSION}" | cut -f 1 -d ' ')
 
-ssh -t "${SRC_HOST}" "docker exec ${CONTAINER_ID} sh -c 'pg_dumpall --verbose --username=postgres' " >sourcegraph_pgall.out
-# ssh -t "${SRC_HOST}" "docker exec ${CONTAINER_ID} sh -c 'pg_dump --verbose --username=postgres sourcegraph-codeintel' " >codeintel_pg.out
+# Dump sourcegraph db and alter script for migration
+ssh ${SRC_HOST} "docker exec ${CONTAINER_ID} pg_dump -C --username=postgres sourcegraph" >${sg_dump_file}
+sed '/^CREATE DATABASE/a CREATE USER postgres WITH SUPERUSER CREATEROLE CREATEDB REPLICATION BYPASSRLS;' ${sg_dump_file}
+printf '\connect -reuse-previous=on dbname=postgres\nDROP DATABASE sg;\nALTER DATABASE "sourcegraph" RENAME TO sg;\nALTER DATABASE sg OWNER TO sg;\n' >> ${sg_dump_file}
 
+# Dump codeintel db and alter script for migration
+ssh ${SRC_HOST} "docker exec ${CONTAINER_ID} pg_dump -C --username=postgres sourcegraph-codeintel" >${codeintel_dump_file}
+sed '/^CREATE DATABASE/a CREATE USER postgres WITH SUPERUSER CREATEROLE CREATEDB REPLICATION BYPASSRLS;' ${codeintel_dump_file}
+printf '\connect -reuse-previous=on dbname=postgres\nDROP DATABASE sg;\nALTER DATABASE "sourcegraph-codeintel" RENAME TO sg;\nALTER DATABASE sg OWNER TO sg;\n' >> ${codeintel_dump_file}
 
-chmod 777 ./*pg.out
-scp ./*pg.out "${DST_HOST}:/tmp/"
+# Upload database dumps to new docker-compose deployment
+chmod 544 ${sg_dump_file} ${codeintel_dump_file}
+scp ${sg_dump_file} "${DST_HOST}:${sg_dump_file}"
+scp ${codeintel_dump_file} "${DST_HOST}:${codeintel_dump_file}"
 
+# Migrate databases and start new deployment
 ssh -t "${DST_HOST}" "
 pushd ${COMPOSE_DIR}
 docker-compose down --volumes
-docker-compose -f pgsql-only-migrate.docker-compose.yaml up -d
-sleep 15
-docker cp /tmp/sourcegraph_pgall.out pgsql:/tmp/
+docker-compose -f db-only-migrate.docker-compose.yaml up -d
+sleep 10
+docker cp ${sg_dump_file} pgsql:${sg_dump_file}
+docker cp ${codeintel_dump_file} codeintel-db:${codeintel_dump_file}
+
+docker exec pgsql sh -c 'psql -v ERROR_ON_STOP=1 -U sg -f ${sg_dump_file} postgres'
+docker exec codeintel-db sh -c 'psql -v ERROR_ON_STOP=1 -U sg -f ${codeintel_dump_file} postgres'
+
+docker-compose -f docker-compose.yaml up -d
+echo 'TEST: Checking frontend is accessible for 1 minute'
+
+for i in {1..6}; do
+curl -f http://localhost:80
+curl -f http://localhost:80/healthz
+sleep 10
+done
 "
 
-# docker exec pgsql sh -c 'psql -v ERROR_ON_STOP=1 -U sg -f /tmp/sourcegraph_pg.out postgres'
-#  docker exec pgsql sh -c 'psql -U sg postgres -c \"DROP DATABASE sg;\"'
-# docker exec pgsql sh -c 'psql -U sg postgres -c \"ALTER DATABASE sourcegraph RENAME TO sg; ALTER DATABASE sg OWNER TO sg;\"'
-# docker cp codeintel_pg.out codeintel-db:/tmp/
-# docker exec codeintel-db sh -c 'psql -U sg -f /tmp/codeintel_pg.out postgres'
-# docker exec codeintel-db sh -c 'psql -U sg postgres -c \"DROP DATABASE sg;\"'
-# docker exec codeintel-db sh -c 'psql -U sg postgres -c \"ALTER DATABASE sourcegraph-codeintel RENAME TO sg; ALTER DATABASE sg OWNER TO sg;\"'
-
-# pushd ${COMPOSE_DIR}
-# docker-compose -f docker-compose.yaml up -d
-# sleep 30
-# curl localhost 2>&1 | grep sign-in

--- a/tools/migrate.sh
+++ b/tools/migrate.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # shellcheck source=migration_vars
 source migration_vars
 
-IMAGE=${IMAGE:-sourcegraph/server}
+iamge=${image:-sourcegraph/server}
 sg_dump_file=$(mktemp)
 codeintel_dump_file=$(mktemp)
 
@@ -13,29 +13,29 @@ trap 'rm -f ${sg_dump_file} ${codeintel_dump_file}' EXIT
 
 # Get the  ID of the sourcegraph container
 echo "Obtaing sourcegraph container ID"
-CONTAINER_ID=$(ssh "${SRC_HOST}" docker ps | grep "${IMAGE}:${VERSION}" | cut -f 1 -d ' ')
+container_id=$(ssh "${src_host}" docker ps | grep "${image}:${version}" | cut -f 1 -d ' ')
 
 # Dump sourcegraph db and alter script for migration
 echo "Dumping sourcegraph database"
-ssh ${SRC_HOST} "docker exec ${CONTAINER_ID} pg_dump -C --username=postgres sourcegraph" >${sg_dump_file}
-sed -n --silent '/^CREATE DATABASE/a CREATE USER postgres WITH SUPERUSER CREATEROLE CREATEDB REPLICATION BYPASSRLS;' ${sg_dump_file} > /dev/null 2>&1
-printf '\connect -reuse-previous=on dbname=postgres\nDROP DATABASE sg;\nALTER DATABASE "sourcegraph" RENAME TO sg;\nALTER DATABASE sg OWNER TO sg;\n' >> ${sg_dump_file}
+ssh ${src_host} "docker exec ${container_id} pg_dump -C --username=postgres sourcegraph" >${sg_dump_file}
+sed -n --silent '/^CREATE DATABASE/a CREATE USER postgres WITH SUPERUSER CREATEROLE CREATEDB REPLICATION BYPASSRLS;' ${sg_dump_file} >/dev/null 2>&1
+printf '\connect -reuse-previous=on dbname=postgres\nDROP DATABASE sg;\nALTER DATABASE "sourcegraph" RENAME TO sg;\nALTER DATABASE sg OWNER TO sg;\n' >>${sg_dump_file}
 
 # Dump codeintel db and alter script for migration
 echo "Dumping codeintel database"
-ssh ${SRC_HOST} "docker exec ${CONTAINER_ID} pg_dump -C --username=postgres sourcegraph-codeintel" >${codeintel_dump_file}
-sed -n --silent '/^CREATE DATABASE/a CREATE USER postgres WITH SUPERUSER CREATEROLE CREATEDB REPLICATION BYPASSRLS;' ${codeintel_dump_file} > /dev/null 2>&1
-printf '\connect -reuse-previous=on dbname=postgres\nDROP DATABASE sg;\nALTER DATABASE "sourcegraph-codeintel" RENAME TO sg;\nALTER DATABASE sg OWNER TO sg;\n' >> ${codeintel_dump_file}
+ssh ${src_host} "docker exec ${container_id} pg_dump -C --username=postgres sourcegraph-codeintel" >${codeintel_dump_file}
+sed -n --silent '/^CREATE DATABASE/a CREATE USER postgres WITH SUPERUSER CREATEROLE CREATEDB REPLICATION BYPASSRLS;' ${codeintel_dump_file} >/dev/null 2>&1
+printf '\connect -reuse-previous=on dbname=postgres\nDROP DATABASE sg;\nALTER DATABASE "sourcegraph-codeintel" RENAME TO sg;\nALTER DATABASE sg OWNER TO sg;\n' >>${codeintel_dump_file}
 
 # Upload database dumps to new docker-compose deployment
 echo "Uploading dumps to new deployment"
 chmod 544 ${sg_dump_file} ${codeintel_dump_file}
-scp ${sg_dump_file} "${DST_HOST}:${sg_dump_file}"
-scp ${codeintel_dump_file} "${DST_HOST}:${codeintel_dump_file}"
+scp ${sg_dump_file} "${dst_host}:${sg_dump_file}"
+scp ${codeintel_dump_file} "${dst_host}:${codeintel_dump_file}"
 
 # Migrate databases and start new deployment
-ssh -t "${DST_HOST}" "
-pushd ${COMPOSE_DIR}
+ssh -t "${dst_host}" "
+pushd ${compose_dir}
 docker-compose down --volumes
 docker-compose -f db-only-migrate.docker-compose.yaml up -d
 sleep 10
@@ -56,4 +56,3 @@ sleep 10
 done
 echo 'Migration completed'
 "
-

--- a/tools/migrate.sh
+++ b/tools/migrate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Please ensure the variales in migration vars have been assigned before running this script. 
+# Please ensure the variables in migration vars have been assigned before running this script. 
 
 set -euxo pipefail
 

--- a/tools/migrate.sh
+++ b/tools/migrate.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# shellcheck source=migration_vars
+source migration_vars
+
+TMPFILE=$(mktemp)
+IMAGE=${IMAGE:-sourcegraph/server}
+
+trap 'rm -f "${TMPFILE}"' EXIT
+
+CONTAINER_ID=$(ssh "${SRC_HOST}" docker ps | grep "${IMAGE}:${VERSION}" | cut -f 1 -d ' ')
+
+ssh -t "${src_host}" "docker exec ${CONTAINER_ID} sh -c 'pg_dumpall --verbose --username=postgres' " >"${TMPFILE}"
+
+ssh -t ${DST_HOST} "
+pushd ${COMPOSE_DIR}
+docker-compose down --volumes
+docker-compose -f pgsql-only-migrate.docker-compose.yaml up -d
+"
+
+scp "$TMPFILE" "${DST_HOST}:$TMPFILE"
+
+ssh -t "${DST_HOST}" "
+docker cp ${TMPFILE} pgsql:${TMPFILE}
+docker exec -u root pgsql sh -c 'psql -U sg -f ${TMPFILE} postgres'
+docker exec pgsql sh -c 'psql -U sg postgres -c \"DROP DATABASE sg;\"'
+docker exec pgsql sh -c 'psql -U sg postgres -c \"ALTER DATABASE sourcegraph RENAME TO sg; ALTER DATABASE sg OWNER TO sg;\"'
+pushd ${COMPOSE_DIR}
+docker-compose -f docker-compose.yaml up -d
+sleep 30
+curl localhost 2>&1 | grep sign-in
+"
+
+

--- a/tools/migrate.sh
+++ b/tools/migrate.sh
@@ -4,8 +4,10 @@
 
 set -euxo pipefail
 
+(
 # shellcheck source=migration_vars
 source migration_vars
+)
 
 image=${image:-sourcegraph/server}
 sg_dump_file=$(mktemp)

--- a/tools/migrate.sh
+++ b/tools/migrate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Please ensure the variales in migration vars have been assigned before running this script. 
+
 set -euxo pipefail
 
 # shellcheck source=migration_vars
@@ -9,7 +11,7 @@ image=${image:-sourcegraph/server}
 sg_dump_file=$(mktemp)
 codeintel_dump_file=$(mktemp)
 
-# trap 'rm -f ${sg_dump_file} ${codeintel_dump_file}' EXIT
+trap 'rm -f ${sg_dump_file} ${codeintel_dump_file}' EXIT
 
 # Get the  ID of the sourcegraph container
 echo "Obtaing sourcegraph container ID"

--- a/tools/migrate.sh
+++ b/tools/migrate.sh
@@ -5,32 +5,35 @@ set -euxo pipefail
 # shellcheck source=migration_vars
 source migration_vars
 
-TMPFILE=$(mktemp)
 IMAGE=${IMAGE:-sourcegraph/server}
-
-trap 'rm -f "${TMPFILE}"' EXIT
+# trap 'rm -f ./*pg.out' EXIT
 
 CONTAINER_ID=$(ssh "${SRC_HOST}" docker ps | grep "${IMAGE}:${VERSION}" | cut -f 1 -d ' ')
 
-ssh -t "${src_host}" "docker exec ${CONTAINER_ID} sh -c 'pg_dumpall --verbose --username=postgres' " >"${TMPFILE}"
+ssh -t "${SRC_HOST}" "docker exec ${CONTAINER_ID} sh -c 'pg_dumpall --verbose --username=postgres' " >sourcegraph_pgall.out
+# ssh -t "${SRC_HOST}" "docker exec ${CONTAINER_ID} sh -c 'pg_dump --verbose --username=postgres sourcegraph-codeintel' " >codeintel_pg.out
 
-ssh -t ${DST_HOST} "
+
+chmod 777 ./*pg.out
+scp ./*pg.out "${DST_HOST}:/tmp/"
+
+ssh -t "${DST_HOST}" "
 pushd ${COMPOSE_DIR}
 docker-compose down --volumes
 docker-compose -f pgsql-only-migrate.docker-compose.yaml up -d
+sleep 15
+docker cp /tmp/sourcegraph_pgall.out pgsql:/tmp/
 "
 
-scp "$TMPFILE" "${DST_HOST}:$TMPFILE"
+# docker exec pgsql sh -c 'psql -v ERROR_ON_STOP=1 -U sg -f /tmp/sourcegraph_pg.out postgres'
+#  docker exec pgsql sh -c 'psql -U sg postgres -c \"DROP DATABASE sg;\"'
+# docker exec pgsql sh -c 'psql -U sg postgres -c \"ALTER DATABASE sourcegraph RENAME TO sg; ALTER DATABASE sg OWNER TO sg;\"'
+# docker cp codeintel_pg.out codeintel-db:/tmp/
+# docker exec codeintel-db sh -c 'psql -U sg -f /tmp/codeintel_pg.out postgres'
+# docker exec codeintel-db sh -c 'psql -U sg postgres -c \"DROP DATABASE sg;\"'
+# docker exec codeintel-db sh -c 'psql -U sg postgres -c \"ALTER DATABASE sourcegraph-codeintel RENAME TO sg; ALTER DATABASE sg OWNER TO sg;\"'
 
-ssh -t "${DST_HOST}" "
-docker cp ${TMPFILE} pgsql:${TMPFILE}
-docker exec -u root pgsql sh -c 'psql -U sg -f ${TMPFILE} postgres'
-docker exec pgsql sh -c 'psql -U sg postgres -c \"DROP DATABASE sg;\"'
-docker exec pgsql sh -c 'psql -U sg postgres -c \"ALTER DATABASE sourcegraph RENAME TO sg; ALTER DATABASE sg OWNER TO sg;\"'
-pushd ${COMPOSE_DIR}
-docker-compose -f docker-compose.yaml up -d
-sleep 30
-curl localhost 2>&1 | grep sign-in
-"
-
-
+# pushd ${COMPOSE_DIR}
+# docker-compose -f docker-compose.yaml up -d
+# sleep 30
+# curl localhost 2>&1 | grep sign-in

--- a/tools/migration_vars
+++ b/tools/migration_vars
@@ -8,13 +8,13 @@ set -u
 IMAGE=
 
 # The sourcegraph version running on both the source and destination hosts. NOTE: this version must be the same when migration data ie : 3.24.1
-VERSION=3.24.1
+VERSION=
 
 # The username and hostname of the host you will be migrating from. Takes the form of username@host ie: sourcegraph-user@myhost
-SRC_HOST=dave-dev
+SRC_HOST=
 
 # The username and hostname of the host you will be migrating too. Takes the form of username@host ie: sourcegraph-user@myhost
-DST_HOST=dave-dev
+DST_HOST=
 
 # Fully qualified path to the docker-compose directory on a host
-COMPOSE_DIR=/home/dave/sourcegraph/deploy-sourcegraph-docker/docker-compose
+COMPOSE_DIR=

--- a/tools/migration_vars
+++ b/tools/migration_vars
@@ -8,13 +8,13 @@ set -u
 IMAGE=
 
 # The sourcegraph version running on both the source and destination hosts. NOTE: this version must be the same when migration data ie : 3.24.1
-VERSION=
+VERSION=3.24.1
 
 # The username and hostname of the host you will be migrating from. Takes the form of username@host ie: sourcegraph-user@myhost
-SRC_HOST=
+SRC_HOST=dave-dev
 
 # The username and hostname of the host you will be migrating too. Takes the form of username@host ie: sourcegraph-user@myhost
-DST_HOST=
+DST_HOST=dave-dev
 
 # Fully qualified path to the docker-compose directory on a host
-COMPOSE_DIR=
+COMPOSE_DIR=/home/dave/sourcegraph/deploy-sourcegraph-docker/docker-compose

--- a/tools/migration_vars
+++ b/tools/migration_vars
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -u
+
+# Please populate the following variables with details of your migration
+
+# The name of the sourcegraph server image. Defaults to "sourcegraph/server"
+IMAGE=
+
+# The sourcegraph version running on both the source and destination hosts. NOTE: this version must be the same when migration data ie : 3.24.1
+VERSION=
+
+# The username and hostname of the host you will be migrating from. Takes the form of username@host ie: sourcegraph-user@myhost
+SRC_HOST=
+
+# The username and hostname of the host you will be migrating too. Takes the form of username@host ie: sourcegraph-user@myhost
+DST_HOST=
+
+# Fully qualified path to the docker-compose directory on a host
+COMPOSE_DIR=


### PR DESCRIPTION
A script to migrate Sourcegraph single server deployments to compose:

I chose editing the dump file for sql commands as the bash foo to escape quotes was awful. Happy to revisit this if someone disagrees but I feel as though I burnt too much time here before it occurred to me it'd just be easier do it this way. 

fixes https://github.com/sourcegraph/sourcegraph/issues/11600