### PR TITLE
codeinsights-db: correct data volume path

### DIFF
--- a/deploy-codeinsights-db.sh
+++ b/deploy-codeinsights-db.sh
@@ -18,7 +18,6 @@ docker run --detach \
     --cpus=4 \
     --memory=2g \
     -e POSTGRES_PASSWORD=password \
-    -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
     index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
 

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -531,7 +531,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=password
     volumes:
-      - "codeinsights-db:/data/"
+      - "codeinsights-db:/var/lib/postgresql/data/"
     networks:
       - sourcegraph
     restart: always


### PR DESCRIPTION
I failed to verify `/data` was the correct path (it is for our other Postgres images, but not for this TimescaleDB image), which means codeinsights-db data is not being retained currently. I noticed this because the DB was lost on sourcegraph.com (chart looks empty.)

The good news is that I am actively working on building historical data for insights, so this data loss doesn't really matter - it'll all be rebuilt later.

Fixes https://github.com/sourcegraph/sourcegraph/issues/18704

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/1936
* [x] All images have a valid tag and SHA256 sum
