### PR TITLE
insights: set PGDATA=/var/lib/postgresql/data/pgdata

### DIFF
--- a/deploy-codeinsights-db.sh
+++ b/deploy-codeinsights-db.sh
@@ -18,6 +18,7 @@ docker run --detach \
     --cpus=4 \
     --memory=2g \
     -e POSTGRES_PASSWORD=password \
+    -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
     index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
 

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -530,6 +530,7 @@ services:
     mem_limit: "2g"
     environment:
       - POSTGRES_PASSWORD=password
+      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - "codeinsights-db:/var/lib/postgresql/data/"
     networks:


### PR DESCRIPTION
I previously thought `PGDATA=/var/lib/postgresql/data/pgdata` was the default,
but it is definitely not: `/var/lib/postgresql/data` is.

I removed this from `deploy-codeinsights-db.sh` for consistency with the Docker
Compose deployment, but this would have broken existing pure-docker deployments
because they were storing data in the `pgdata` subdirectory previously.

I have added this to Docker Compose deployments here, for consistency, although
it is not strictly required (Docker Compose volumes, unlike Kubernetes ones, do
not appear ot have a `lost+found` file in them and as such Postgres is happy to
use the root of the volume - whereas in Kubernetes deployments it will complain
the directory is not empty and fail to start.)

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/1936
* [x] All images have a valid tag and SHA256 sum
