### PR TITLE
use healthcheck to fix db lock

### DIFF
--- a/deploy-frontend-internal.sh
+++ b/deploy-frontend-internal.sh
@@ -18,6 +18,11 @@ docker run --detach \
     --restart=always \
     --cpus=4 \
     --memory=8g \
+    --health-cmd="wget -q 'http://127.0.0.1:3080/healthz' -O /dev/null || exit 1" \
+    --health-interval=5s \
+    --health-timeout=10s \
+    --health-retries=3 \
+    --health-start-period=300s \
     -e DEPLOY_TYPE=pure-docker \
     -e GOMAXPROCS=4 \
     -e PGHOST=pgsql \

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,6 +29,13 @@ for i in $(seq 0 $(($NUM_INDEXED_SEARCH - 1))); do ./deploy-zoekt-webserver.sh $
 
 # Redis must be started before these.
 ./deploy-frontend-internal.sh
+# Wait for frontend-internal to run migrations before starting remaining frontend containers
+while [ "$(docker inspect sourcegraph-frontend-internal --format '{{.State.Status}}')" != "running" ]
+do
+  echo "waiting for interal frontend to start"
+  sleep 5
+done
+
 for i in $(seq 0 $(($NUM_FRONTEND - 1))); do ./deploy-frontend.sh $i; done
 ./deploy-caddy.sh
 wait

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -101,6 +101,9 @@ services:
     networks:
       - sourcegraph
     restart: always
+    depends_on:
+      sourcegraph-frontend-internal:
+        condition: service_healthy
 
   # Description: Serves the internal Sourcegraph frontend API.
   #
@@ -135,6 +138,12 @@ services:
     networks:
       - sourcegraph
     restart: always
+    healthcheck:
+      test: "wget -q 'http://127.0.0.1:3080/healthz' -O /dev/null || exit 1"
+      interval: 5s
+      timeout: 10s
+      retries: 3
+      start_period: 300s
 
   # Description: Stores clones of repositories to perform Git operations.
   #
@@ -519,7 +528,7 @@ services:
   # Network: 1Gbps
   # Ports exposed to other Sourcegraph services: 5432/TCP 9187/TCP
   # Ports exposed to the public internet: none
-  # 
+  #
   # Note: You should deploy this as a container, do not try to connect it to your external
   # Postgres deployment (TimescaleDB is a bit special and most hosted Postgres deployments
   # do not support TimescaleDB, the data here is akin to gitserver's data, where losing it


### PR DESCRIPTION
This stops the frontend containers competing for a lock and erroring during the migrations. 

This ensures the internal pod comes up first, as other services start to talk to this before an user would start accessing the UI. In addition, if a customer wants to create multiple replicas of the frontend the start order and potential conflict between containers is still accounted for. 