### PR TITLE
Configure healthcheck for sourcegraph-internal

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -144,6 +144,12 @@ services:
       timeout: 10s
       retries: 5
       start_period: 300s
+    depends_on:
+      pgsql:
+        condition: service_healthy
+      codeintel-db:
+        condition: service_healthy
+
 
   # Description: Stores clones of repositories to perform Git operations.
   #
@@ -490,7 +496,7 @@ services:
       test: '/liveness.sh'
       interval: 10s
       timeout: 1s
-      retries: 3
+      retries: 10
       start_period: 15s
     volumes:
       - 'pgsql:/data/'
@@ -514,7 +520,7 @@ services:
       test: '/liveness.sh'
       interval: 10s
       timeout: 1s
-      retries: 3
+      retries: 10
       start_period: 15s
     volumes:
       - 'codeintel-db:/data/'


### PR DESCRIPTION
Sourcegraph-internal will fail once if the relevant dbs are not up. This results in the docker-compose deployment failing to start until `docker-compose up -d` is ran again.

Adds `depends_on` to sourcegraph-internal for the codeintel-db & pgsql db

Fixes https://github.com/sourcegraph/sourcegraph/issues/20326


