### PR TITLE
bump memory limits for redis-[cache,store] to 7 GB

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -591,7 +591,7 @@ services:
     container_name: redis-cache
     image: 'index.docker.io/sourcegraph/redis-cache:insiders@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56'
     cpus: 1
-    mem_limit: '6g'
+    mem_limit: '7g'
     volumes:
       - 'redis-cache:/redis-data'
     networks:
@@ -607,7 +607,7 @@ services:
     container_name: redis-store
     image: 'index.docker.io/sourcegraph/redis-store:insiders@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168'
     cpus: 1
-    mem_limit: '6g'
+    mem_limit: '7g'
     volumes:
       - 'redis-store:/redis-data'
     networks:


### PR DESCRIPTION
Both redis-cache and redis-store  have `maxmemory 6gb` in their redis.conf: https://github.com/sourcegraph/infrastructure/blob/main/docker-images/redis-cache/redis.conf#L4 and https://github.com/sourcegraph/infrastructure/blob/3d83a92ce64650f46754e2ac55c3accfe84ab0d7/docker-images/redis-store/redis.conf#L4.  According to https://redis.io/topics/lru-cache#eviction-policies, redis will start evicting things from its cache once it hits that limit. However, because our _k8s pod_ memory limits are also set to 6 GB - k8s will kill the redis pods before they have a chance to perform that eviction process. 

Giving redis one more gigabyte to work with should give it enough room to do its cache eviction without being OOMKilled

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/2898
* [x] All images have a valid tag and SHA256 sum
