### PR TITLE
ensure hostname matches container name

### DIFF
--- a/deploy-gitserver.sh
+++ b/deploy-gitserver.sh
@@ -18,7 +18,7 @@ docker run --detach \
     --restart=always \
     --cpus=4 \
     --memory=8g \
-    --hostname=gitserver-0 \
+    --hostname=gitserver-$1 \
     -e GOMAXPROCS=4 \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST=jaeger \


### PR DESCRIPTION
ensures each gitserver replica has a unique hostname that matches the container name

Fixes https://github.com/sourcegraph/customer/issues/318#issuecomment-833655421