### PR TITLE
Introduce worker service

### DIFF
--- a/deploy-precise-code-intel-worker.sh
+++ b/deploy-precise-code-intel-worker.sh
@@ -13,7 +13,8 @@ docker run --detach \
     --restart=always \
     --cpus=2 \
     --memory=4g \
-    -e 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090' \
+    -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
+    -e JAEGER_AGENT_HOST=jaeger \
     index.docker.io/sourcegraph/precise-code-intel-worker:insiders@sha256:b635e06165d1e6a4ca7573f7aa97baba7e392d88b83d7cee8752928202db94a1
 
 echo "Deployed precise-code-intel-worker service"

--- a/deploy-worker.sh
+++ b/deploy-worker.sh
@@ -22,6 +22,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST=jaeger \
     -v $VOLUME:/mnt/cache \
-    index.docker.io/sourcegraph/repo-updater:insiders@sha256:53f0fcd28885d379c1c9046028e45ae2b96be4a34a0011afacb133d76bc82bb6
+    index.docker.io/sourcegraph/worker:97840_2021-06-02_d90a77b_patch@sha256:7fb1f7a4d009f2ab7343f5d34b6fc2fb2dcd9950df87e9b840e1c13b99b21c4a
 
-echo "Deployed repo-updater service"
+echo "Deployed worker service"

--- a/deploy-worker.sh
+++ b/deploy-worker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+source ./replicas.sh
+
+# Description: Manages background processes.
+#
+# Disk: 128GB / non-persistent SSD
+# Network: 100mbps
+# Liveness probe: n/a
+# Ports exposed to other Sourcegraph services: 3189/TCP 6060/TCP
+# Ports exposed to the public internet: none
+#
+VOLUME="$HOME/sourcegraph-docker/worker-disk"
+./ensure-volume.sh $VOLUME 100
+docker run --detach \
+    --name=worker \
+    --network=sourcegraph \
+    --restart=always \
+    --cpus=4 \
+    --memory=4g \
+    -e GOMAXPROCS=1 \
+    -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
+    -e JAEGER_AGENT_HOST=jaeger \
+    -v $VOLUME:/mnt/cache \
+    index.docker.io/sourcegraph/repo-updater:insiders@sha256:53f0fcd28885d379c1c9046028e45ae2b96be4a34a0011afacb133d76bc82bb6
+
+echo "Deployed repo-updater service"

--- a/deploy-worker.sh
+++ b/deploy-worker.sh
@@ -22,6 +22,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST=jaeger \
     -v $VOLUME:/mnt/cache \
-    index.docker.io/sourcegraph/worker:97840_2021-06-02_d90a77b_patch@sha256:7fb1f7a4d009f2ab7343f5d34b6fc2fb2dcd9950df87e9b840e1c13b99b21c4a
+    index.docker.io/sourcegraph/worker:insiders@sha256:c724fc8d29c30135d30e41a798b6a7688b5eda0a3b9a7b74753faf7028c02b41
 
 echo "Deployed worker service"

--- a/deploy.sh
+++ b/deploy.sh
@@ -21,6 +21,7 @@ for i in $(seq 0 $(($NUM_GITSERVER - 1))); do ./deploy-gitserver.sh $i; done
 ./deploy-redis-cache.sh
 ./deploy-redis-store.sh
 ./deploy-repo-updater.sh
+./deploy-worker.sh
 for i in $(seq 0 $(($NUM_SEARCHER - 1))); do ./deploy-searcher.sh $i; done
 for i in $(seq 0 $(($NUM_SYMBOLS - 1))); do ./deploy-symbols.sh $i; done
 ./deploy-syntect-server.sh

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -336,7 +336,7 @@ services:
   #
   worker:
     container_name: worker
-    image: 'index.docker.io/sourcegraph/worker:insiders'
+    image: 'index.docker.io/sourcegraph/worker:97840_2021-06-02_d90a77b_patch@sha256:7fb1f7a4d009f2ab7343f5d34b6fc2fb2dcd9950df87e9b840e1c13b99b21c4a'
     cpus: 4
     mem_limit: '4g'
     environment:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -336,7 +336,7 @@ services:
   #
   worker:
     container_name: worker
-    image: 'index.docker.io/sourcegraph/worker:97840_2021-06-02_d90a77b_patch@sha256:7fb1f7a4d009f2ab7343f5d34b6fc2fb2dcd9950df87e9b840e1c13b99b21c4a'
+    image: 'index.docker.io/sourcegraph/worker:insiders@sha256:c724fc8d29c30135d30e41a798b6a7688b5eda0a3b9a7b74753faf7028c02b41'
     cpus: 4
     mem_limit: '4g'
     environment:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -274,6 +274,7 @@ services:
     mem_limit: '4g'
     environment:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
+      - JAEGER_AGENT_HOST=jaeger
     healthcheck:
       test: "wget -q 'http://127.0.0.1:3188/healthz' -O /dev/null || exit 1"
       interval: 5s
@@ -323,6 +324,27 @@ services:
       - 'GITHUB_BASE_URL=http://github-proxy:3180'
     volumes:
       - 'repo-updater:/mnt/cache'
+    networks:
+      - sourcegraph
+    restart: always
+
+  # Description: Manages background processes.
+  #
+  # Disk: 128GB / non-persistent SSD
+  # Ports exposed to other Sourcegraph services: 3189/TCP 6060/TCP
+  # Ports exposed to the public internet: none
+  #
+  worker:
+    container_name: worker
+    image: 'index.docker.io/sourcegraph/worker:insiders'
+    cpus: 4
+    mem_limit: '4g'
+    environment:
+      - GOMAXPROCS=1
+      - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
+      - JAEGER_AGENT_HOST=jaeger
+    volumes:
+      - 'worker:/mnt/cache'
     networks:
       - sourcegraph
     restart: always
@@ -620,6 +642,7 @@ volumes:
   redis-cache:
   redis-store:
   repo-updater:
+  worker:
   searcher-0:
   sourcegraph-frontend-0:
   sourcegraph-frontend-internal-0:

--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -26,6 +26,10 @@
   targets:
     - repo-updater:6060
 - labels:
+    job: worker
+  targets:
+    - worker:6060
+- labels:
     job: node
   targets:
     - syntect-server:6060

--- a/teardown.sh
+++ b/teardown.sh
@@ -20,6 +20,7 @@ docker rm -f query-runner &> /dev/null || true &
 docker rm -f redis-cache &> /dev/null || true &
 docker rm -f redis-store &> /dev/null || true &
 docker rm -f repo-updater &> /dev/null || true &
+docker rm -f worker &> /dev/null || true &
 docker rm -f $(addresses "searcher-" $NUM_SEARCHER "") &> /dev/null || true &
 docker rm -f $(addresses "symbols-" $NUM_SYMBOLS "") &> /dev/null || true &
 docker rm -f syntect-server &> /dev/null || true &

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -10,14 +10,14 @@ deploy_sourcegraph() {
 
 		if [[ "$GIT_BRANCH" == *"customer-replica"* ]]; then
 			# Expected number of containers on e.g. 3.18-customer-replica branch.
-			expect_containers="60"
+			expect_containers="61"
 		else
 			# Expected number of containers on `master` branch.
-			expect_containers="25"
+			expect_containers="26"
 		fi
 	elif [[ "$TEST_TYPE" == "docker-compose-test" ]]; then
 		docker-compose --file docker-compose/docker-compose.yaml up -d
-		expect_containers="23"
+		expect_containers="24"
 	fi
 
 	echo "Giving containers 30s to start..."

--- a/test/volume-config.sh
+++ b/test/volume-config.sh
@@ -14,7 +14,6 @@ echo
 #
 # IMPORTANT: If these change, or a new service is introduced, it must be explicitly called out in
 # https://docs.sourcegraph.com/admin/updates/pure_docker similar to https://docs.sourcegraph.com/admin/updates/pure_docker#v3-12-5-v3-13-2-changes
-# TODO: Note instructions above (putting here so we have a diff catch as well)
 echo
 echo "forcing static permissions on volume directories"
 echo

--- a/test/volume-config.sh
+++ b/test/volume-config.sh
@@ -14,11 +14,12 @@ echo
 #
 # IMPORTANT: If these change, or a new service is introduced, it must be explicitly called out in
 # https://docs.sourcegraph.com/admin/updates/pure_docker similar to https://docs.sourcegraph.com/admin/updates/pure_docker#v3-12-5-v3-13-2-changes
+# TODO: Note instructions above (putting here so we have a diff catch as well)
 echo
 echo "forcing static permissions on volume directories"
 echo
 pushd ~/sourcegraph-docker
-chown -R 100:101 gitserver* prometheus-v2* repo-updater* searcher* sourcegraph-frontend* symbols* zoekt* minio-disk
+chown -R 100:101 gitserver* prometheus-v2* worker* repo-updater* searcher* sourcegraph-frontend* symbols* zoekt* minio-disk
 chown -R 999:1000 redis-store-disk redis-cache-disk
 chown -R 472:472 grafana-disk
 chown -R 999:999 pgsql-disk codeintel-db-disk codeinsights-db-disk


### PR DESCRIPTION
This PR introduces a deployment for the new `worker` service. Currently this service replaces background jobs related to codeintel that used to occur in each frontend. Additional background services will make its way into this service. Part of sourcegraph/sourcegraph#21761.

Related changes:
- [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph/pull/3082)
- [deploy-sourcegraph-dot-com](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pull/7786)
- [deploy-sourcegraph-dogfood-k8s-2](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2/pull/1884)