### PR TITLE
Add 'stop_grace_period to database services

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -524,6 +524,7 @@ services:
     networks:
       - sourcegraph
     restart: always
+    stop_grace_period: 120s
 
   # Description: PostgreSQL database for code intelligence data.
   #
@@ -548,6 +549,7 @@ services:
     networks:
       - sourcegraph
     restart: always
+    stop_grace_period: 120s
 
   # Description: TimescaleDB time-series database for code insights data.
   #
@@ -573,6 +575,7 @@ services:
     networks:
       - sourcegraph
     restart: always
+    stop_grace_period: 120s
 
   # Description: MinIO for storing LSIF uploads.
   #


### PR DESCRIPTION
This gives Postgres more time to gracefully shutdown

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
