### PR TITLE
Fix Jaeger Tracing in Docker Compose

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -502,6 +502,8 @@ services:
       - sourcegraph
     restart: always
     command: ['--memory.max-traces=20000']
+    environment:
+      - 'SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json'
 
   # Description: PostgreSQL database for various data.
   #


### PR DESCRIPTION
<!-- description here -->
Jaeger is not working on Docker Compose currently due to missing env var stated in https://github.com/sourcegraph/sourcegraph/issues/21677#issuecomment-889433798
This PR adds the missing env var SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json so that jaeger can work on Docker Compose instances properly. 


### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
