### PR TITLE
prometheus: scrape pg, redis instances by default

### DIFF
--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -2,15 +2,6 @@
 - labels:
     job: node
   targets:
-    # Uncomment these if you want to monitor PostgreSQL / Redis via Prometheus.
-    #- pgsql:9187
-    #- codeintel-db:9187
-    #- codeinsights-db:9187
-    #- redis-cache:9121
-    #- redis-store:9121
-- labels:
-    job: node
-  targets:
     - cadvisor:8080
     - sourcegraph-frontend-internal:6060
 - labels:
@@ -58,3 +49,23 @@
     job: symbols
   targets:
     - symbols-0:6060
+- labels:
+    job: pgsql
+  targets:
+    - pgsql:9187
+- labels:
+    job: codeintel-db
+  targets:
+    - codeintel-db:9187
+- labels:
+    job: codeinsights-db
+  targets:
+    - codeinsights-db:9187
+- labels:
+    job: redis-cache
+  targets:
+    - redis-cache:9121
+- labels:
+    job: redis-store
+  targets:
+    - redis-store:9121


### PR DESCRIPTION
<!-- description here -->

Convenience and parity with k8s (would have been useful for https://github.com/sourcegraph/customer/issues/470 where I realized too late they were on Compose)

Without this the postgres dashboards are also super unhelpful on Compose, e.g. https://demo.sourcegraph.com/-/debug/grafana/d/postgres/postgres?orgId=1 

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
