### PR TITLE
docker-compose.yml: spell certificates correctly

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
     volumes:
       - 'caddy:/caddy-storage'
       #
-      # Comment out the following line when using HTTPS with either Let's Encrypt or custom certficates
+      # Comment out the following line when using HTTPS with either Let's Encrypt or custom certificates
       - '../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile'
       #
       # Uncomment the following line when using HTTPS with Let's Encrypt's staging environment
@@ -45,10 +45,10 @@ services:
       # Uncomment the following line when using HTTPS with custom certificates
       # - '../caddy/builtins/https.custom-cert.Caddyfile:/etc/caddy/Caddyfile'
       #
-      # Uncomment / update the following line when using HTTPS with custom certficates
+      # Uncomment / update the following line when using HTTPS with custom certificates
       # - '/LOCAL/CERT/PATH.pem:/sourcegraph.pem'
       #
-      # Uncomment / update the following line when using HTTPS with custom certficates
+      # Uncomment / update the following line when using HTTPS with custom certificates
       # - '/LOCAL/KEY/PATH.key:/sourcegraph.key'
     ports:
       - '0.0.0.0:80:80'


### PR DESCRIPTION
https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph+certficates&patternType=literal

Related change: https://github.com/sourcegraph/handbook/pull/311