### PR TITLE
Adding a note on where to mount internal CAs

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -67,6 +67,8 @@ services:
   # lists which each allow you to specify more container instances for scaling
   # purposes. Be sure to also apply such a change here to the frontend-internal
   # service.
+  #
+  # Note: Mount internal CA's into /etc/ssl/certs
   sourcegraph-frontend-0:
     container_name: sourcegraph-frontend-0
     image: 'index.docker.io/sourcegraph/frontend:insiders@sha256:7c453e79a63e92b79901a6b523859d43e870f978162a60a4b219a6e54aa6c98a'


### PR DESCRIPTION
This change adds a note for users who have internally signed CA's and who would want to know where to mount them.

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
