### PR TITLE
Update minio envvars to new convention

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -572,8 +572,8 @@ services:
     cpus: 1
     mem_limit: '1g'
     environment:
-      - 'MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE'
-      - 'MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+      - 'MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE'
+      - 'MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://127.0.0.1:9000/minio/health/live']
       interval: 10s

--- a/pure-docker/deploy-minio.sh
+++ b/pure-docker/deploy-minio.sh
@@ -19,7 +19,7 @@ docker run --detach \
     --memory=1g \
     -p 0.0.0.0:9000:9000 \
     -v $VOLUME:/data \
-    -e MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE \
-    -e MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+    -e MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE \
+    -e MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
     index.docker.io/sourcegraph/minio:insiders@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f \
     server /data


### PR DESCRIPTION
Update minio environment variables to new convention. 
Addresses https://github.com/sourcegraph/sourcegraph/issues/26529.

[_Created by Sourcegraph batch change `kevin.wojkovich/minio-envvar-update`._](https://k8s.sgdev.org/users/kevin.wojkovich/batch-changes/minio-envvar-update)