### PR TITLE
buildkite: explicitly target queue in CI

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,25 +5,26 @@ env:
 steps:
   - label: ':docker:'
     command: .buildkite/validate-docker-compose.sh
-    agents:
-      queue: 'baremetal'
+    agents: { queue: 'baremetal' }
+
   - label: ':lipstick:'
     command: .buildkite/prettier-check.sh
-    agents:
-      queue: 'baremetal'
+    agents: { queue: 'baremetal' }
+
   - label: ":git: :sleuth_or_spy:"
-    command: .buildkite/verify-release/verify-release.sh      
+    command: .buildkite/verify-release/verify-release.sh
+    agents: { queue: standard }
+
   - label: ':rice: pure-docker-test'
     command: .buildkite/vagrant-run.sh docker-test
     artifact_paths: ./*.log
-    agents:
-      queue: 'baremetal'
     env:
       TEST_TYPE: 'pure-docker-test'
+    agents: { queue: 'baremetal' }
+
   - label: ':rice: docker-compose-test'
     command: .buildkite/vagrant-run.sh docker-test
     artifact_paths: ./*.log
-    agents:
-      queue: 'baremetal'
     env:
       TEST_TYPE: 'docker-compose-test'
+    agents: { queue: 'baremetal' }


### PR DESCRIPTION
related to https://github.com/sourcegraph/infrastructure/pull/2939

Prevents accidental assignment to test agents

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/4031
* [ ] All images have a valid tag and SHA256 sum
