### PR TITLE
Update default pgsql docker image for pure-docker, process changes

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -76,14 +76,15 @@ git checkout 3.8-customer-replica
 # Create the new pure-docker release branch
 git checkout -B 3.9-customer-replica
 
-# Merge the publish-3.9 branch, which will have been created by the release tool, into the pure-docker release branch.
-git merge publish-3.9
+# Merge the publish-3.9 branch, which will have been created by the release tool, into the pure-docker release branch. Default to taking the remote changes.
+git merge publish-3.9 -X theirs
+
+# Reset to previous commit so we can manually inspect ALL changes - we want to create multiple commits instead of keeping a single merge commit
+git reset HEAD~
 
 # Show which files may have been deleted, etc.
 git status
 
-# Reset to HEAD so we can manually inspect ALL changes - we do not want to actually do a merge.
-git reset HEAD
 ```
 
 At this point you should evaluate the `git status` output as well as all the changes in your working git directory. You need to ensure the following happens:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -93,7 +93,6 @@ At this point you should evaluate the `git status` output as well as all the cha
     - `git commit -m 'merge 3.9 (changes unrelated to upgrade)'`
 3. Create **one** commit with the changes _customers need to apply in order to ugprade_, i.e. the image tag changes, adding/removing any new services, updating env vars, but no unrelated changes.
     - Do not include `docker-compose/` changes in this commit, those are irrelevant to pure-docker users.
-    - Doublecheck the version in pure-docker/deploy-pgsql.sh - it often fails to merge correctly and uses an incorrect value.
     - `git commit -m 'upgrade to v3.9.0'`
 
 During this process you will run into two merge conflicts:

--- a/pure-docker/deploy-pgsql.sh
+++ b/pure-docker/deploy-pgsql.sh
@@ -19,7 +19,7 @@ docker run --detach \
     --memory=2g \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
-    index.docker.io/sourcegraph/postgres-12.6:95244_2021-05-06_2c1f77e@sha256:35040317490324a15e1259c9023a726eb27c694530f6f8877e87d337c7b97778
+    index.docker.io/sourcegraph/postgres-12.6-alpine:insiders@sha256:263a7293092ca1ab85c06b6bb7103998345ec9d65daf9b4c48b0a14bb39d984f
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,
 # but anything 12 and higher is supported.


### PR DESCRIPTION
I realized that the reason the pgsql version for pure-docker releases never updated is that the initial batch change wasn't updating the version. The container image in master was never updated to the new name, so the update-tags script couldn't find it.

I also included a small usability change on the pure-docker update process, so we don't have to resolve merge conflicts. In the next stage, we visually inspect the diffs and revert any unnecessary changes so this should be safe.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
