### PR TITLE
Add cpus setting for zoekt-indexserver-0

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -184,6 +184,7 @@ services:
   zoekt-indexserver-0:
     container_name: zoekt-indexserver-0
     image: 'index.docker.io/sourcegraph/search-indexer:insiders@sha256:c0eed47bb3bdaff187501d7f6f0336ab407a2bdc8581fe8163ca973dde4f5d76'
+    cpus: 8
     mem_limit: '16g'
     environment:
       - GOMAXPROCS=8


### PR DESCRIPTION
The zoekt-indexserver-0 deployment used to have cpus specified but it was removed in [this commit](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/6cf878cdbfd1ea298209f1d08ae39dbd88c8e101) in 2020. It seems like that was unintentional. Without this setting, Grafana dashboards that rely on cadvisor metrics aren't tracking cpu usage, since there is no specified limit:

![missing cpu](https://user-images.githubusercontent.com/91073224/151625753-9ce415cb-3f25-491c-9576-c03e43070598.png)

I'm uncertain of the impact of this change on the performance of indexserver: without the cpu setting, it may have had unlimited cpu usage and could now be throttled in cases where 8 cpus is not sufficient. However, the GOMAXPROCS setting may have already been limiting this behavior, and the corrected monitoring will allow easier tracking.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [X] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: No change needed, cpu limit is already set
* [ ] All images have a valid tag and SHA256 sum
