### PR TITLE
Update `pure_docker` release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,6 +67,8 @@ For pure-docker, we provide customers with an exact diff of changes to make. The
 
 To reduce the chance for errors, we send an exact diff of changes. This diff needs to be as minimal and concise as possible, and e.g. not include changes to unrelated files like `.prettierignore` or `docker-compose/` to avoid any confusion. See https://docs.sourcegraph.com/admin/updates/pure_docker for examples of what these diffs look like.
 
+### Major/Minor release
+
 Pretend `3.8` was the last version of pure-docker release (look for the latest `n.n-customer-replica` branch), and that `3.9` is the version we want to release. Then:
 
 ```sh
@@ -127,6 +129,75 @@ git push origin customer-replica-v3.9.0
 Write an entry for https://docs.sourcegraph.com/admin/updates/pure_docker which includes:
 
 - A link to your `upgrade to v3.9.0` commit describing the exact changes needed to be made.
+- Any specific manual migrations, including potential `chown` commands that may be needed (if any new service is introduced, etc.)
+- Look at https://github.com/sourcegraph/sourcegraph/pulls?q=is%3Apr+is%3Aopen+pure-docker to see if there are any open PRs that might need to be included.
+
+### Patch release
+
+Pretend `3.8` was the last version of pure-docker release (look for the latest `n.n-customer-replica` branch), and that `3.8.1` is the version we want to release. Then:
+
+```sh
+# Checkout the current pure-docker release branch
+git checkout 3.8-customer-replica
+
+# Create the new pure-docker release branch
+git checkout -B 3.8.1-customer-replica
+
+# Merge the publish-3.8.1 branch, which will have been created by the release tool, into the pure-docker release branch. Default to taking the remote changes.
+git merge publish-3.8.1 -X theirs
+
+# Reset to previous commit so we can manually inspect ALL changes - we want to create multiple commits instead of keeping a single merge commit
+git reset HEAD~
+
+# Show which files may have been deleted, etc.
+git status
+
+```
+
+At this point you should evaluate the `git status` output as well as all the changes in your working git directory. You need to ensure the following happens:
+
+1. Files that were shown as deleted in the `git status` output get deleted in the relevant commit.
+2. Create **one** commit with changes _unrelated to the upgrade_, i.e. include ALL changes that are not directly related to upgrading:
+    - `git commit -m 'merge 3.8.1 (changes unrelated to upgrade)'`
+3. Create **one** commit with the changes _customers need to apply in order to ugprade_, i.e. the image tag changes, adding/removing any new services, updating env vars, but no unrelated changes.
+    - Do not include `docker-compose/` changes in this commit, those are irrelevant to pure-docker users.
+    - Double check `pure-docker/deploy-pgsql.sh` file and make sure it has the correct image sha. It should look something like `index.docker.io/sourcegraph/postgres-12.6-alpine:3.36.3@sha256:<hash>`
+    - `git commit -m 'upgrade to v3.8.1'`
+
+During this process you will run into two merge conflicts:
+
+- Do not commit: `deploy-caddy.sh` or changes related to it, as `deploy-apache.sh` is used here.
+- The prettier ignore should look like this:
+
+```
+.github/
+*.md
+rootfs/etc/docker/daemon.json
+```
+
+1. Push the changes to github
+```shell
+git push --set-upstream origin 3.8.1-customer-replica
+```
+
+Open a Pull Request against `3.8-customer-replica` (base branch)
+
+Check buildkite for the branch after pushing it, e.g. at https://github.com/sourcegraph/deploy-sourcegraph-docker/commits/3.19-customer-replica
+
+This will take about ~10 minutes to run. Refer to the [testing documentation](TESTING.md) if you run into issues / need more instructions.
+
+Once you see `ALL TESTS PASSED`, merge the Pull Request and tag a new release
+
+```sh
+git checkout 3.8-customer-replica
+git pull
+git tag customer-replica-v3.8.1
+git push origin customer-replica-v3.8.1
+```
+
+Write an entry for https://docs.sourcegraph.com/admin/updates/pure_docker which includes:
+
+- A link to your `upgrade to v3.8.1` commit describing the exact changes needed to be made.
 - Any specific manual migrations, including potential `chown` commands that may be needed (if any new service is introduced, etc.)
 - Look at https://github.com/sourcegraph/sourcegraph/pulls?q=is%3Apr+is%3Aopen+pure-docker to see if there are any open PRs that might need to be included.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,6 +94,7 @@ At this point you should evaluate the `git status` output as well as all the cha
     - `git commit -m 'merge 3.9 (changes unrelated to upgrade)'`
 3. Create **one** commit with the changes _customers need to apply in order to ugprade_, i.e. the image tag changes, adding/removing any new services, updating env vars, but no unrelated changes.
     - Do not include `docker-compose/` changes in this commit, those are irrelevant to pure-docker users.
+    - Double check `pure-docker/deploy-pgsql.sh` file and make sure it has the correct image sha. It should look something like `index.docker.io/sourcegraph/postgres-12.6-alpine:3.36.3@sha256:<hash>`
     - `git commit -m 'upgrade to v3.9.0'`
 
 During this process you will run into two merge conflicts:


### PR DESCRIPTION
- Add notes to validate deploy-psql.sql. Remind me to not mess up `deploy-psql.sh` again.
- Add a new section to document process of patch release in light of the branch protection rule