### PR TITLE
Update renovate configuration to match deploy-sourcegraph schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,10 @@
 {
   "$schema": "http://json.schemastore.org/renovate",
   "extends": ["config:base"],
-  "prHourlyLimit": 0,
+  "prHourlyLimit": 5,
+  "schedule": [
+    "before 3am on Monday"
+  ],
   "packageRules": [
     {
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
@@ -10,7 +13,7 @@
       "versionScheme": "semver",
       "ignoreUnstable": false,
       "semanticCommits": false,
-      "automerge": false
+      "automerge": true
     },
     {
       "packageNames": ["index.docker.io/sourcegraph/grafana", "index.docker.io/sourcegraph/prometheus"],
@@ -19,7 +22,7 @@
       "versionScheme": "semver",
       "ignoreUnstable": false,
       "semanticCommits": false,
-      "automerge": false
+      "automerge": true
     },
     {
       "groupName": "Sourcegraph Docker images list",


### PR DESCRIPTION
Change the renovate configuration slightly to follow the pattern found in [deploy-sourcegraph](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph/-/blob/renovate.json).

Notably, images should only try to update once a week instead of constantly, and the PR's should try to automerge.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
