### PR TITLE
Bump sourcegraph/update-docker-tags to v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.15
 
 require (
 	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220206113006-a13c81ec36fb
-	github.com/sourcegraph/update-docker-tags v0.9.0
+	github.com/sourcegraph/update-docker-tags v0.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -178,3 +178,5 @@ github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-2022020611300
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220206113006-a13c81ec36fb/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
 github.com/sourcegraph/update-docker-tags v0.9.0 h1:FeqPS1GH5n4KyTha/SpZvDDmrdS4c+N8cQ3xb4Rlb+A=
 github.com/sourcegraph/update-docker-tags v0.9.0/go.mod h1:lCDsoUnk/ASDbm7UxE7tU3qAUhQxA7xykELHXcLeKFM=
+github.com/sourcegraph/update-docker-tags v0.10.0 h1:KpY1HtvSt0FzDM/sR0jQF5StNbiPKpqmHhE0jpBEa0A=
+github.com/sourcegraph/update-docker-tags v0.10.0/go.mod h1:lCDsoUnk/ASDbm7UxE7tU3qAUhQxA7xykELHXcLeKFM=


### PR DESCRIPTION
https://github.com/sourcegraph/update-docker-tags/releases/tag/v0.10.0

[_Created by Sourcegraph batch change `sourcegraph/bump-update-docker-tags-v0.10.0`._](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes/bump-update-docker-tags-v0.10.0)