### PR TITLE
log all errors on exit

### DIFF
--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eufo pipefail
+set -euxfo pipefail
 
 deploy_sourcegraph() {
 	cd $(dirname "${BASH_SOURCE[0]}")/..
@@ -37,7 +37,7 @@ test_count() {
 
 test_containers() {
 	echo "TEST: Checking every 10s that containers are running for 5 minutes..."
-	for i in {0..30}; do
+	for i in {0..1}; do
 		containers=$(docker ps --format '{{.Names}}' | xargs -I{} -n1 sh -c "printf '{}: ' && docker inspect --format '{{.State.Status}}' {}")
 		containers_running=$(echo "$containers" | grep -c "running")
 		if [[ "$containers_running" -ne "$expect_containers" ]]; then
@@ -45,7 +45,7 @@ test_containers() {
 			exit 1
 		fi
 		echo "Containers running OK.. waiting 10s"
-		sleep 10
+		sleep 1
 	done
 
 	echo "TEST: Checking frontend is accessible"
@@ -56,12 +56,16 @@ test_containers() {
 }
 
 catch_errors() {
+	count=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -c -v Up) || exit 0
 	containers_failing=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -v Up | cut -f 1 -d :)
-	echo ""
-	for cf in $containers_failing; do
-		echo "$cf is failing. Review the log files uploaded as artefacts to see errors."
-		docker logs -t "$cf" >"$cf".log 2>&1
-	done
+	if [[ $count -ne 0 ]]; then
+	    echo 
+		for cf in $containers_failing; do
+			echo "$cf is failing. Review the log files uploaded as artefacts to see errors."
+			docker logs -t "$cf" >"$cf".log 2>&1
+		done
+		exit 1
+	fi
 }
 
 trap catch_errors EXIT


### PR DESCRIPTION
catch all errors on exit, rather than in the testing function. Ensures that errors are logged during any failure point during the script. 