### PR TITLE
tweak frontend healthcheck

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -143,9 +143,9 @@ services:
       - 'NEW_MIGRATIONS=true'
     healthcheck:
       test: "wget -q 'http://127.0.0.1:3080/healthz' -O /dev/null || exit 1"
-      interval: 5s
+      interval: 10s
       timeout: 10s
-      retries: 5
+      retries: 10
       start_period: 300s
     volumes:
       - 'sourcegraph-frontend-0:/mnt/cache'
@@ -153,9 +153,7 @@ services:
       - sourcegraph
     restart: always
     depends_on:
-      pgsql:
-        condition: service_healthy
-      codeintel-db:
+      sourcegraph-frontend-internal:
         condition: service_healthy
 
   # Description: Serves the internal Sourcegraph frontend API.


### PR DESCRIPTION
### Test Plan

Deploy `3.36.3` (comment out `migrator` and set `NEW_MIGRATION=false`)

> You should set `CR_USERNAME` and `CR_PASSWORD` env var to avoid rate limiting

```bash
./tools/update-docker-tags.sh 3.36.3
```

Set db to read only to simulate migration failure

```bash
docker-compose exec pgsql bash
ALTER DATABASE sg SET default_transaction_read_only = true;
```

Deploy the new insiders build with migrators

`migrator` and `sourcegraph-frontend-internal` are broken, but `frontend-0` is still accessible and healthy.

```
caddy                           caddy run --config /etc/ca ...   Up             2019/tcp, 0.0.0.0:443->443/tcp, 0.0.0.0:80->80/tcp
cadvisor                        /usr/bin/cadvisor -logtost ...   Restarting
codeinsights-db                 docker-entrypoint.sh postgres    Up             5432/tcp
codeintel-db                    /postgres.sh                     Up (healthy)   5432/tcp
github-proxy                    /sbin/tini -- /usr/local/b ...   Up
gitserver-0                     /sbin/tini -- /usr/local/b ...   Up
grafana                         /entry.sh                        Up             3000/tcp, 0.0.0.0:3370->3370/tcp
jaeger                          /go/bin/all-in-one-linux - ...   Up             0.0.0.0:14250->14250/tcp, 14268/tcp, 0.0.0.0:16686->16686/tcp, 5775/udp, 0.0.0.0:5778->5778/tcp,
                                                                                0.0.0.0:6831->6831/tcp, 6831/udp, 0.0.0.0:6832->6832/tcp, 6832/udp
migrator                        /sbin/tini -- /usr/local/b ...   Restarting
minio                           /usr/bin/docker-entrypoint ...   Up (healthy)   9000/tcp
pgsql                           /postgres.sh                     Up (healthy)   5432/tcp
precise-code-intel-worker       /sbin/tini -- /usr/local/b ...   Up (healthy)   3188/tcp
prometheus                      /bin/prom-wrapper                Up             0.0.0.0:9090->9090/tcp
redis-cache                     /sbin/tini -- redis-server ...   Up             6379/tcp
redis-store                     /sbin/tini -- redis-server ...   Up             6379/tcp
repo-updater                    /sbin/tini -- /usr/local/b ...   Up
searcher-0                      /sbin/tini -- /usr/local/b ...   Up (healthy)
sourcegraph-frontend-0          /sbin/tini -- /usr/local/b ...   Up (healthy)
sourcegraph-frontend-internal   /sbin/tini -- /usr/local/b ...   Restarting
symbols-0                       /sbin/tini -- /usr/local/b ...   Up (healthy)   3184/tcp
syntect-server                  sh -c /http-server-stabili ...   Up (healthy)   9238/tcp
worker                          /sbin/tini -- /usr/local/b ...   Up             3189/tcp
zoekt-indexserver-0             /sbin/tini -- zoekt-source ...   Up
zoekt-webserver-0               /sbin/tini -- /bin/sh -c z ...   Up (healthy)
```