### PR TITLE
Add postgres_exporter

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -550,6 +550,26 @@ services:
     restart: always
     stop_grace_period: 120s
 
+  # Description: This container will collect and expose prometheus metrics about `pgsql` PostgreSQL server.
+  #
+  # Disk: None
+  # Ports exposed to other Sourcegraph services: 9187/TCP
+  # Ports exposed to the public internet: none
+  #
+  # If you're using a DB instance hosted outside of docker-compose, the environment variables
+  # for this container will need to be updated to reflect the new connection information.
+  pgsql-exporter:
+    container_name: pgsql-exporter
+    image: 'index.docker.io/sourcegraph/postgres_exporter:3.37.0@sha256:20e58b62f064037ac3d901eba565f49d7e1daae2a237e6fa3d5351580d576dea'
+    cpus: 0.1
+    mem_limit: '50m'
+    networks:
+      - sourcegraph
+    restart: always
+    environment:
+      - 'DATA_SOURCE_NAME=postgres://sg:@pgsql:5432/?sslmode=disable'
+      - 'PG_EXPORTER_EXTEND_QUERY_PATH=/config/queries.yaml'
+
   # Description: PostgreSQL database for code intelligence data.
   #
   # Disk: 128GB / persistent SSD
@@ -574,6 +594,26 @@ services:
       - sourcegraph
     restart: always
     stop_grace_period: 120s
+
+  # Description: This container will collect and expose prometheus metrics about `codeintel-db` PostgreSQL server.
+  #
+  # Disk: None
+  # Ports exposed to other Sourcegraph services: 9187/TCP
+  # Ports exposed to the public internet: none
+  #
+  # If you're using a DB instance hosted outside of docker-compose, the environment variables
+  # for this container will need to be updated to reflect the new connection information.
+  codeintel-db-exporter:
+    container_name: codeintel-db-exporter
+    image: 'index.docker.io/sourcegraph/postgres_exporter:3.37.0@sha256:20e58b62f064037ac3d901eba565f49d7e1daae2a237e6fa3d5351580d576dea'
+    cpus: 0.1
+    mem_limit: '50m'
+    networks:
+      - sourcegraph
+    restart: always
+    environment:
+      - 'DATA_SOURCE_NAME=postgres://sg:@pgsql:5432/?sslmode=disable'
+      - 'PG_EXPORTER_EXTEND_QUERY_PATH=/config/code_intel_queries.yaml'
 
   # Description: TimescaleDB time-series database for code insights data.
   #

--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -48,11 +48,11 @@
 - labels:
     job: pgsql
   targets:
-    - pgsql:9187
+    - pgsql-exporter:9187
 - labels:
     job: codeintel-db
   targets:
-    - codeintel-db:9187
+    - codeintel-db-exporter:9187
 - labels:
     job: codeinsights-db
   targets:


### PR DESCRIPTION
This PR adds [postgres_exporter](https://github.com/sourcegraph/sourcegraph/tree/main/docker-images/postgres_exporter) to docker-compose deployment

### Checklist

* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum

### TODO

- [ ] Should we port this to pure docker?
  - Is it even useful to users?
- [ ] Deploy exporter on `demo`. Is it a good idea?

### Test plan

Download https://gist.github.com/michaellzc/ef1cace336ad46c24571d9328cbf763b#file-docker-compose-override-yaml

```
docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
```

Go to http://localhost:9090/targets, the following endpoint should be healthy

- http://codeintel-db-exporter:9187/metrics
- http://pgsql-exporter:9187/metrics

Go to http://localhost:3370/-/debug/grafana/d/postgres/postgres?orgId=1, graph that relies on pg explorer should no longer be empty.

Fix https://github.com/sourcegraph/customer/issues/726, https://github.com/sourcegraph/customer/issues/718