### PR TITLE
Reduce default resources on migrator container

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -14,8 +14,8 @@ services:
   migrator:
     container_name: migrator
     image: 'index.docker.io/sourcegraph/migrator:insiders@sha256:0127103905f36f4799ed18282453e4c8b378feb12e03a143ddf95484b4e04e17'
-    cpus: 1
-    mem_limit: '2g'
+    cpus: 0.5
+    mem_limit: '500m'
     command:
       ["up"]
     environment:


### PR DESCRIPTION
Adjust the defaults on the migrator container to be consistent with https://github.com/sourcegraph/deploy-sourcegraph/pull/4095. These are still probably too generous, but it's closer!

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [X] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph/pull/4095) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Ran docker-compose locally and confirmed migrator still worked.