### PR TITLE
Migrate codeinsights-db to vanilla postgres image

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -48,6 +48,8 @@ services:
     depends_on:
       pgsql:
         condition: service_healthy
+      codeinsights-db:
+        condition: service_healthy
       codeintel-db:
         condition: service_healthy
 
@@ -619,31 +621,79 @@ services:
       - 'DATA_SOURCE_NAME=postgres://sg:@codeintel-db:5432/?sslmode=disable'
       - 'PG_EXPORTER_EXTEND_QUERY_PATH=/config/code_intel_queries.yaml'
 
-  # Description: TimescaleDB time-series database for code insights data.
+  # Description: This container will update file permissions on the
+  # `codeinsights` database
+  #
+  # Disk: None
+  # Ports: None
+  #
+  # This container should mount the codeinsights volume, change ownership on the files,
+  # and then exit cleanly. After exiting the `codeinsights-db` service is allowed to start.
+  #
+  codeinsights-chown:
+    container_name: codeinsights-chown
+    image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:290c7a045f18b8dab3021e6d5667f751b44c5bd488c408ebd387a802a4bf4876
+    cpus: 0.1
+    mem_limit: '10m'
+    command: ["sh", "-c", "if [ -d /var/lib/postgresql/data/ ]; then chown -R 999:999 /var/lib/postgresql/data/; fi"]
+    restart: "on-failure"
+    networks:
+      - sourcegraph
+    volumes:
+      - 'codeinsights-db:/var/lib/postgresql/data/'
+
+  # Description: PostgreSQL database for code insights data.
   #
   # Disk: 128GB / persistent SSD
   # Network: 1Gbps
   # Ports exposed to other Sourcegraph services: 5432/TCP 9187/TCP
   # Ports exposed to the public internet: none
   #
-  # Note: You should deploy this as a container, do not try to connect it to your external
-  # Postgres deployment (TimescaleDB is a bit special and most hosted Postgres deployments
-  # do not support TimescaleDB, the data here is akin to gitserver's data, where losing it
-  # would be bad but it can be rebuilt given enough time.)
   codeinsights-db:
     container_name: codeinsights-db
-    image: 'index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:82fe7f91dbdca1cd397a80f1023d9da4e9c6af103bc36866d800e3a8279eea00'
+    image: 'index.docker.io/sourcegraph/postgres-12-alpine:135107_2022-03-03_9498a8bd3366@sha256:e26b159dc7c0c47d136886390c899816e669a3c2c1ead689bdad0b610364e45e'
     cpus: 4
     mem_limit: '2g'
     environment:
       - POSTGRES_PASSWORD=password
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
       - PGDATA=/var/lib/postgresql/data/pgdata
+    healthcheck:
+      test: '/liveness.sh'
+      interval: 10s
+      timeout: 1s
+      retries: 10
+      start_period: 15s
     volumes:
       - 'codeinsights-db:/var/lib/postgresql/data/'
     networks:
       - sourcegraph
     restart: always
     stop_grace_period: 120s
+    depends_on:
+      codeinsights-chown:
+        condition: service_completed_successfully
+
+  # Description: This container will collect and expose prometheus metrics about `codeinsights-db` PostgreSQL server.
+  #
+  # Disk: None
+  # Ports exposed to other Sourcegraph services: 9187/TCP
+  # Ports exposed to the public internet: none
+  #
+  # If you're using a DB instance hosted outside of docker-compose, the environment variables
+  # for this container will need to be updated to reflect the new connection information.
+  codeinsights-db-exporter:
+    container_name: codeinsights-db-exporter
+    image: 'index.docker.io/sourcegraph/postgres_exporter:3.37.0@sha256:20e58b62f064037ac3d901eba565f49d7e1daae2a237e6fa3d5351580d576dea'
+    cpus: 0.1
+    mem_limit: '50m'
+    networks:
+      - sourcegraph
+    restart: always
+    environment:
+      - 'DATA_SOURCE_NAME=postgres://postgres:password@codeinsights-db:5432/postgres?sslmode=disable'
+      - 'PG_EXPORTER_EXTEND_QUERY_PATH=/config/code_insights_queries.yaml'
 
   # Description: MinIO for storing LSIF uploads.
   #

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -628,14 +628,18 @@ services:
   # Ports: None
   #
   # This container should mount the codeinsights volume, change ownership on the files,
-  # and then exit cleanly. After exiting the `codeinsights-db` service is allowed to start.
+  # remove any reference to the timescaledb library, and then exit cleanly.
+  # After exiting the `codeinsights-db` service is allowed to start.
   #
   codeinsights-chown:
     container_name: codeinsights-chown
     image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:290c7a045f18b8dab3021e6d5667f751b44c5bd488c408ebd387a802a4bf4876
     cpus: 0.1
     mem_limit: '10m'
-    command: ["sh", "-c", "if [ -d /var/lib/postgresql/data/ ]; then chown -R 999:999 /var/lib/postgresql/data/; fi"]
+    command:
+      - "sh"
+      - "-c"
+      - if [ -d /var/lib/postgresql/data/ ]; then chown -R 999:999 /var/lib/postgresql/data/; sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'timescaledb(.*)\'/\1 = '\2'/;s/,'/'/" /var/lib/postgresql/data/pgdata/postgresql.conf; fi
     restart: "on-failure"
     networks:
       - sourcegraph

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -621,25 +621,25 @@ services:
       - 'DATA_SOURCE_NAME=postgres://sg:@codeintel-db:5432/?sslmode=disable'
       - 'PG_EXPORTER_EXTEND_QUERY_PATH=/config/code_intel_queries.yaml'
 
-  # Description: This container will update file permissions on the
-  # `codeinsights` database
+  # Description: This container will update the postgres configuration
+  # on the `codeinsights` database
   #
   # Disk: None
   # Ports: None
   #
-  # This container should mount the codeinsights volume, change ownership on the files,
-  # remove any reference to the timescaledb library, and then exit cleanly.
+  # This container should mount the codeinsights volume, remove any
+  # reference to the timescaledb library, and then exit cleanly.
   # After exiting the `codeinsights-db` service is allowed to start.
   #
-  codeinsights-chown:
-    container_name: codeinsights-chown
+  codeinsights-fix-conf:
+    container_name: codeinsights-fix-conf
     image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:290c7a045f18b8dab3021e6d5667f751b44c5bd488c408ebd387a802a4bf4876
     cpus: 0.1
     mem_limit: '10m'
     command:
       - "sh"
       - "-c"
-      - if [ -d /var/lib/postgresql/data/ ]; then chown -R 999:999 /var/lib/postgresql/data/; sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'timescaledb(.*)\'/\1 = '\2'/;s/,'/'/" /var/lib/postgresql/data/pgdata/postgresql.conf; fi
+      - if [ -d /var/lib/postgresql/data/pgdata ]; then sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'timescaledb(.*)\'/\1 = '\2'/;s/,'/'/" /var/lib/postgresql/data/pgdata/postgresql.conf; fi
     restart: "on-failure"
     networks:
       - sourcegraph
@@ -676,7 +676,7 @@ services:
     restart: always
     stop_grace_period: 120s
     depends_on:
-      codeinsights-chown:
+      codeinsights-fix-conf:
         condition: service_completed_successfully
 
   # Description: This container will collect and expose prometheus metrics about `codeinsights-db` PostgreSQL server.


### PR DESCRIPTION
Switch codeinsights to use the vanilla Postgres image.

Due to the uid mismatch between TimescaleDB and our Postgres image, we need to change existing file ownership (uid 70) to match the new uid (999). In this approach, we're running `chown` as a standalone container that will run before codeinsights-db starts up. This container can be removed in the 3.39 release.

Three concerns:
- `service_completed_successfully` requires a newer version of Docker Compose than we currently require (https://github.com/sourcegraph/sourcegraph/issues/32077). If this is a dealbreaker we may be able to get away with just letting codeinsights-db crash until the chown runs. **Update**: I think this is ok, we can make an update in the upgrade doc to tell customers to run the command separately.
- The performance cost of running the `chown` command is unknown. This needs to be tested against a larger dataset (insightstest), although the number of files involved should not be too unbearable. If it's too bad, we can always fall back to requiring customers to run a manual migration step. **Update:** no issue seen against insightstest
- The `sed` command in the chown container is a tiny bit risky. It definitely works for the pre-built postgresql.conf but if a customer has added their own things get messy. We'll need to rely on adding a warning during the upgrade notes (although I think there are very few customers who would have customized their conf in docker-compose).

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Run through a migration on insightstest and measure performance / UX.