### PR TITLE
Swap codeinsights to vanilla postgres

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -632,7 +632,7 @@ services:
   # would be bad but it can be rebuilt given enough time.)
   codeinsights-db:
     container_name: codeinsights-db
-    image: 'index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:da1e7ad250d5eeffc1057f8c4cf6c65c6ebb3ae2aa898451b3d1d87cf8ddef94'
+    image: 'postgres:12.7-alpine'
     cpus: 4
     mem_limit: '2g'
     environment:


### PR DESCRIPTION
Just demoing the swap I'm testing out. `postgres:12.7-alpine` has the same uid as timescale so there are no permissions issues.

Error seen when trying to swap an existing deployment:
```
2022-03-08 21:00:36.119 UTC [1] FATAL:  could not access file "timescaledb": No such file or directory
2022-03-08 21:00:36.119 UTC [1] LOG:  database system is shut down

PostgreSQL Database directory appears to contain a database; Skipping initialization
```

Steps to reproduce:
- Start up docker-compose deployment running v3.37.0
- Update timescaleDB image reference to `postgres:12.7-alpine`
- Error!

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
