### PR TITLE
Update codeintel-db exporter to scrape codeintel-db

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -616,7 +616,7 @@ services:
       - sourcegraph
     restart: always
     environment:
-      - 'DATA_SOURCE_NAME=postgres://sg:@pgsql:5432/?sslmode=disable'
+      - 'DATA_SOURCE_NAME=postgres://sg:@codeintel-db:5432/?sslmode=disable'
       - 'PG_EXPORTER_EXTEND_QUERY_PATH=/config/code_intel_queries.yaml'
 
   # Description: TimescaleDB time-series database for code insights data.


### PR DESCRIPTION
The codeintel-db exporter was scraping metrics from pgsql instead of the codeintel-db database.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
docker-compose up, confirmed exporter connected:
```
time="2022-03-08T21:33:17Z" level=info msg="Starting Server: :9187" source="postgres_exporter.go:1850"
time="2022-03-08T21:33:35Z" level=info msg="Established new database connection to \"codeintel-db:5432\"." source="postgres_exporter.go:983"
time="2022-03-08T21:33:35Z" level=info msg="Semantic Version Changed on \"codeintel-db:5432\": 0.0.0 -> 12.6.0" source="postgres_exporter.go:1552"
```