### PR TITLE
Frontend containers now wait for the migrator to complete

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -198,6 +198,8 @@ services:
         condition: service_healthy
       codeintel-db:
         condition: service_healthy
+      migrator:
+        condition: service_completed_successfully
 
   # Description: Stores clones of repositories to perform Git operations.
   #


### PR DESCRIPTION
The frontend-internal container now depends on the migrator completing successfully, preventing an outage when the migrator fails and fixing some flaky tests / startup failures.

This change was originally part of the initial migrator deployment but had to be rolled back in order for us to upgrade the minimum version of docker-compose (done in https://github.com/sourcegraph/sourcegraph/pull/32631).

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
New deployment started successfully.
Upgrade of deployment was successful.
A failed migrator container blocked the frontend containers from rolling out.