### PR TITLE
use stateless agents on non qa tests

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -13,7 +13,7 @@ steps:
 
   - label: ":git: :sleuth_or_spy:"
     command: .buildkite/verify-release/verify-release.sh
-    agents: { queue: standard }
+    agents: { queue: job }
 
   - label: ":rice: pure-docker-test"
     command: .buildkite/vagrant-run.sh docker-test
@@ -33,4 +33,4 @@ steps:
   # https://www.checkov.io/
   - command: .buildkite/ci-checkov.sh
     label: ":lock: security - checkov"
-    agents: { queue: "standard" }
+    agents: { queue: "job" }

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -13,7 +13,7 @@ steps:
 
   - label: ":git: :sleuth_or_spy:"
     command: .buildkite/verify-release/verify-release.sh
-    agents: { queue: job }
+    agents: { queue: "stateless" }
 
   - label: ":rice: pure-docker-test"
     command: .buildkite/vagrant-run.sh docker-test
@@ -33,4 +33,4 @@ steps:
   # https://www.checkov.io/
   - command: .buildkite/ci-checkov.sh
     label: ":lock: security - checkov"
-    agents: { queue: "job" }
+    agents: { queue: "stateless" }


### PR DESCRIPTION
Migrates some of the other trivial steps in this repo to stateless agents

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

The same jobs on deploy-sourcegraph are already running on stateless agents. Green checks on this PR are also a valid test. 