### PR TITLE
Revert "use stateless agents on non qa tests (#784)"

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -13,7 +13,7 @@ steps:
 
   - label: ":git: :sleuth_or_spy:"
     command: .buildkite/verify-release/verify-release.sh
-    agents: { queue: "stateless" }
+    agents: { queue: standard }
 
   - label: ":rice: pure-docker-test"
     command: .buildkite/vagrant-run.sh docker-test
@@ -33,4 +33,4 @@ steps:
   # https://www.checkov.io/
   - command: .buildkite/ci-checkov.sh
     label: ":lock: security - checkov"
-    agents: { queue: "stateless" }
+    agents: { queue: "standard" }


### PR DESCRIPTION
This reverts commit 333bf6d358b1243e1f2e5b08cfd2276bb60750ab.


### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

not required
