### PR TITLE
Update 3.38 with correct images

### DIFF
--- a/docker-compose/db-only-migrate.docker-compose.yaml
+++ b/docker-compose/db-only-migrate.docker-compose.yaml
@@ -12,7 +12,7 @@ services:
   #
   pgsql:
     container_name: pgsql
-    image: 'index.docker.io/sourcegraph/postgres-12-alpine:135107_2022-03-03_9498a8bd3366@sha256:e26b159dc7c0c47d136886390c899816e669a3c2c1ead689bdad0b610364e45e'
+    image: 'index.docker.io/sourcegraph/postgres-12-alpine:3.38.0@sha256:f5329a359f74670eaa2148c72841f7a15323de3eabd9cb8107e4ddda7a457e7f'
     cpus: 4
     mem_limit: '2g'
     healthcheck:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -540,7 +540,7 @@ services:
   #
   pgsql:
     container_name: pgsql
-    image: 'index.docker.io/sourcegraph/postgres-12-alpine:135107_2022-03-03_9498a8bd3366@sha256:e26b159dc7c0c47d136886390c899816e669a3c2c1ead689bdad0b610364e45e'
+    image: 'index.docker.io/sourcegraph/postgres-12-alpine:3.38.0@sha256:f5329a359f74670eaa2148c72841f7a15323de3eabd9cb8107e4ddda7a457e7f'
     cpus: 4
     mem_limit: '2g'
     healthcheck:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/sourcegraph/deploy-sourcegraph-docker
 go 1.15
 
 require (
-	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220221203738-5dc50158e777
+	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220322172859-e4b181cb4ea9
 	github.com/sourcegraph/update-docker-tags v0.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-2022021307453
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220213074539-25b5aca6ca76/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220221203738-5dc50158e777 h1:LFYi6T39iQhZ/b8Ph8bD/v0jO21g+uZmjmUztwqpHoM=
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220221203738-5dc50158e777/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220322172859-e4b181cb4ea9 h1:dsJMrLAT7i+FzB4RMPrlRyXHTS87MIz5iYtHHg33BfE=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220322172859-e4b181cb4ea9/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
 github.com/sourcegraph/update-docker-tags v0.9.0 h1:FeqPS1GH5n4KyTha/SpZvDDmrdS4c+N8cQ3xb4Rlb+A=
 github.com/sourcegraph/update-docker-tags v0.9.0/go.mod h1:lCDsoUnk/ASDbm7UxE7tU3qAUhQxA7xykELHXcLeKFM=
 github.com/sourcegraph/update-docker-tags v0.10.0 h1:KpY1HtvSt0FzDM/sR0jQF5StNbiPKpqmHhE0jpBEa0A=

--- a/pure-docker/deploy-pgsql.sh
+++ b/pure-docker/deploy-pgsql.sh
@@ -19,7 +19,7 @@ docker run --detach \
     --memory=2g \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
-    index.docker.io/sourcegraph/postgres-12-alpine:135107_2022-03-03_9498a8bd3366@sha256:e26b159dc7c0c47d136886390c899816e669a3c2c1ead689bdad0b610364e45e
+    index.docker.io/sourcegraph/postgres-12-alpine:3.38.0@sha256:f5329a359f74670eaa2148c72841f7a15323de3eabd9cb8107e4ddda7a457e7f
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,
 # but anything 12 and higher is supported.


### PR DESCRIPTION
<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [x] All images have a valid tag and SHA256 sum
### Test plan

Just fixing a missed image tag update.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
