### PR TITLE
Switch the Checkov step to soft-fail

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -34,3 +34,4 @@ steps:
   - command: .buildkite/ci-checkov.sh
     label: ":lock: security - checkov"
     agents: { queue: "standard" }
+    soft_fail: true


### PR DESCRIPTION
Until we can move to using a pinned Checkov image version – the lack of image
pinning is causing the build step to break unpredictably.

### Checklist

* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/4106
* N/A - All images have a valid tag and SHA256 sum

### Test plan

Confirm that the build step no longer hard fails