### PR TITLE
Add password to codeinsights-db-exporter env var

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -676,7 +676,7 @@ services:
       - sourcegraph
     restart: always
     environment:
-      - 'DATA_SOURCE_NAME=postgres://postgres:password@codeinsights-db:5432/postgres?sslmode=disable'
+      - 'DATA_SOURCE_NAME=postgres://postgres:password@codeinsights-db:5432?sslmode=disable'
       - 'PG_EXPORTER_EXTEND_QUERY_PATH=/config/code_insights_queries.yaml'
 
   # Description: MinIO for storing LSIF uploads.

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -676,7 +676,7 @@ services:
       - sourcegraph
     restart: always
     environment:
-      - 'DATA_SOURCE_NAME=postgres://postgres:password@codeinsights-db:5432?sslmode=disable'
+      - 'DATA_SOURCE_NAME=postgres://postgres:password@codeinsights-db:5432/?sslmode=disable'
       - 'PG_EXPORTER_EXTEND_QUERY_PATH=/config/code_insights_queries.yaml'
 
   # Description: MinIO for storing LSIF uploads.

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -676,7 +676,7 @@ services:
       - sourcegraph
     restart: always
     environment:
-      - 'DATA_SOURCE_NAME=postgres://postgres:@codeinsights-db:5432/postgres?sslmode=disable'
+      - 'DATA_SOURCE_NAME=postgres://postgres:password@codeinsights-db:5432/postgres?sslmode=disable'
       - 'PG_EXPORTER_EXTEND_QUERY_PATH=/config/code_insights_queries.yaml'
 
   # Description: MinIO for storing LSIF uploads.


### PR DESCRIPTION
Although the password isn't required for other exporter containers, codeinsights-db-exporter fails to connect unless we provide it here.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Metrics are showing up in devmanaged.sourcegraph.com, which already includes this change.