### PR TITLE
fix: make migrator flags consistent across deployments

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     cpus: 0.5
     mem_limit: '500m'
     command:
-      ["up", "-db=all"]
+      ["up"]
     environment:
       - PGHOST=pgsql
       - PGPORT=5432

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     cpus: 0.5
     mem_limit: '500m'
     command:
-      ["up"]
+      ["up", "-db=all"]
     environment:
       - PGHOST=pgsql
       - PGPORT=5432

--- a/pure-docker/deploy-migrator.sh
+++ b/pure-docker/deploy-migrator.sh
@@ -21,6 +21,6 @@ docker run --detach \
     -e CODEINTEL_PGHOST=codeintel-db \
     -e CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@codeinsights-db:5432/postgres \
     index.docker.io/sourcegraph/migrator:insiders@sha256:38f01f0ac17c04a8c9029444ba9fced0501c6bd75415445c825900efca7bb92c \
-    up --db=all
+    up -db=all
 
 echo "Deployed migrator service"

--- a/pure-docker/deploy-migrator.sh
+++ b/pure-docker/deploy-migrator.sh
@@ -20,6 +20,7 @@ docker run --detach \
     -e CODEINTEL_PGUSER=sg \
     -e CODEINTEL_PGHOST=codeintel-db \
     -e CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@codeinsights-db:5432/postgres \
-    index.docker.io/sourcegraph/migrator:insiders@sha256:38f01f0ac17c04a8c9029444ba9fced0501c6bd75415445c825900efca7bb92c
+    index.docker.io/sourcegraph/migrator:insiders@sha256:38f01f0ac17c04a8c9029444ba9fced0501c6bd75415445c825900efca7bb92c \
+    up --db=all
 
 echo "Deployed migrator service"


### PR DESCRIPTION
<!-- description here -->
A fix that corrects the default behavior of the `migrator` service is included in this release. An attempt to standardize CLI packages in v3.39.0 unintentionally broke the default behavior. In order to guard against this, all command line arguments are explicitly set in the deployment manifest.

https://github.com/sourcegraph/customer/issues/845

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [x] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Manual test on workstation & CI