### PR TITLE
Fix cadvisor unable to report oomkill events

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -491,6 +491,11 @@ services:
     image: 'index.docker.io/sourcegraph/cadvisor:insiders@sha256:3544dba5cd99c429ac62f4773454c8406abe126ba340f34e457b38d828c63395'
     cpus: 1
     mem_limit: '1g'
+    # You may set `privileged` to `false and `cadvisor` will run with reduced privileges.
+    # `cadvisor` requires root privileges in order to display provisioning metrics.
+    # These metrics provide critical information to help you scale the Sourcegraph deployment.
+    # If you would like to bring your own infrastructure monitoring & alerting solution,
+    # you may want to remove the `cadvisor` container completely 
     privileged: true
     volumes:
       - '/:/rootfs:ro'

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -491,6 +491,7 @@ services:
     image: 'index.docker.io/sourcegraph/cadvisor:insiders@sha256:3544dba5cd99c429ac62f4773454c8406abe126ba340f34e457b38d828c63395'
     cpus: 1
     mem_limit: '1g'
+    privileged: true
     volumes:
       - '/:/rootfs:ro'
       - '/var/run:/var/run:ro'
@@ -499,6 +500,8 @@ services:
       - '/dev/disk/:/dev/disk:ro'
       # Uncomment to enable container monitoring on MacOS
       # - '/var/run/docker.sock:/var/run/docker.sock:ro'
+    devices:
+      - '/dev/kmsg'
     networks:
       - sourcegraph
     restart: always

--- a/pure-docker/deploy-cadvisor.sh
+++ b/pure-docker/deploy-cadvisor.sh
@@ -24,6 +24,13 @@ sudo docker run --detach \
     --volume=/sys:/sys:ro \
     --volume=/var/lib/docker/:/var/lib/docker:ro \
     --volume=/dev/disk/:/dev/disk:ro \
+    # You may set `privileged` to `false and `cadvisor` will run with reduced privileges.
+    # `cadvisor` requires root privileges in order to display provisioning metrics.
+    # These metrics provide critical information to help you scale the Sourcegraph deployment.
+    # If you would like to bring your own infrastructure monitoring & alerting solution,
+    # you may want to remove the `cadvisor` container completely 
+    --privileged \
+    --device=/dev/kmsg \
     index.docker.io/sourcegraph/cadvisor:3.36.3@sha256:249c573262967979889a186344ba5cc4e8e9186ec4f26c759ce9f8527560da69 \
     --port=8080
 


### PR DESCRIPTION
context: https://sourcegraph.slack.com/archives/C02Q9G9A59S/p1650667926243749?thread_ts=1650662753.412789&cid=C02Q9G9A59S

on managed instances, all cadvisor is reporting such an error
```sh
$ docker logs cadvisor 2>&1  | grep "OOM"
W0420 16:11:04.614936       1 manager.go:296] Could not configure a source for OOM detection, disabling OOM events: open /dev/kmsg: no such file or directory
```

We think this is the cause of `container_oom_events_total` is always zero.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Pending for validation https://github.com/sourcegraph/deploy-sourcegraph-managed/pull/444

it works

![CleanShot 2022-04-25 at 17 39 58](https://user-images.githubusercontent.com/8373004/165196547-e055964f-6ab7-40f2-b331-5a77ef93edb2.png)
