### PR TITLE
Clarify db-only-migrate.docker-compose.yaml

### DIFF
--- a/docker-compose/db-only-migrate.docker-compose.yaml
+++ b/docker-compose/db-only-migrate.docker-compose.yaml
@@ -1,4 +1,4 @@
-# This file contains only the pgsql service definition, and is used during
+# This file contains the pgsql service definitions, and is used during
 # the sourcegraph/server -> docker-compose migration process.
 #
 # 🚨This file MUST be kept in sync with the pgsql definition in docker-compose/docker-compose.yaml

--- a/docker-compose/db-only-migrate.docker-compose.yaml
+++ b/docker-compose/db-only-migrate.docker-compose.yaml
@@ -1,5 +1,6 @@
-# This file contains the pgsql service definitions, and is used during
-# the sourcegraph/server -> docker-compose migration process.
+# This file contains the pgsql service definition (the primary Sourcegraph database deployment), 
+# as well as the codeintel-db service definition (a separate postgres deployment). Both run postgres.
+# This file is used during the sourcegraph/server -> docker-compose migration process.
 #
 # 🚨This file MUST be kept in sync with the pgsql definition in docker-compose/docker-compose.yaml
 version: '2.4'


### PR DESCRIPTION
<!-- description here -->

Wondering if this very, very small change is more correct. There are technically now two services in this file, right? And they're both postgres? If the change is more correct, then I will also create the same change for our Kubernetes repo.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: Not applicable.
* [x] All images have a valid tag and SHA256 sum
### Test plan
None. Though confidence gained from [Slack thread](https://sourcegraph.slack.com/archives/C02E4HE42BX/p1650918019969739), between myself and @kevinwojo .

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
