### PR TITLE
pure-docker: add postgres configuration file mounts

### DIFF
--- a/pure-docker/deploy-codeinsights-db.sh
+++ b/pure-docker/deploy-codeinsights-db.sh
@@ -27,6 +27,7 @@ docker run --detach \
     -e POSTGRES_USER=postgres \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
+    -v ../codeinsights-db/conf:/conf \
     index.docker.io/sourcegraph/codeinsights-db:3.36.3@sha256:98133abeb1fc6d02ee9f0fca6cc3ab65e2a3a47a07db96a56aa0869389393fce
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,

--- a/pure-docker/deploy-codeinsights-db.sh
+++ b/pure-docker/deploy-codeinsights-db.sh
@@ -27,7 +27,7 @@ docker run --detach \
     -e POSTGRES_USER=postgres \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
-    -v ../codeinsights-db/conf:/conf \
+    -v $PWD/../codeinsights-db/conf:/conf \
     index.docker.io/sourcegraph/codeinsights-db:3.36.3@sha256:98133abeb1fc6d02ee9f0fca6cc3ab65e2a3a47a07db96a56aa0869389393fce
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,

--- a/pure-docker/deploy-codeintel-db.sh
+++ b/pure-docker/deploy-codeintel-db.sh
@@ -19,6 +19,7 @@ docker run --detach \
     --memory=2g \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
+    -v ../codeintel-db/conf:/conf \
     index.docker.io/sourcegraph/codeintel-db:3.36.3@sha256:fe3e956733e6ad3599c79d8ca8754249281eb3918aab110e99189cc9b052e28a
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,

--- a/pure-docker/deploy-codeintel-db.sh
+++ b/pure-docker/deploy-codeintel-db.sh
@@ -19,7 +19,7 @@ docker run --detach \
     --memory=2g \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
-    -v ../codeintel-db/conf:/conf \
+    -v $PWD/../codeintel-db/conf:/conf \
     index.docker.io/sourcegraph/codeintel-db:3.36.3@sha256:fe3e956733e6ad3599c79d8ca8754249281eb3918aab110e99189cc9b052e28a
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,

--- a/pure-docker/deploy-pgsql.sh
+++ b/pure-docker/deploy-pgsql.sh
@@ -19,7 +19,7 @@ docker run --detach \
     --memory=2g \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
-    -v ../codeinsights-db/conf:/conf \
+    -v $PWD/../codeinsights-db/conf:/conf \
     index.docker.io/sourcegraph/postgres-12-alpine:135107_2022-03-03_9498a8bd3366@sha256:e26b159dc7c0c47d136886390c899816e669a3c2c1ead689bdad0b610364e45e
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,

--- a/pure-docker/deploy-pgsql.sh
+++ b/pure-docker/deploy-pgsql.sh
@@ -19,6 +19,7 @@ docker run --detach \
     --memory=2g \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
+    -v ../codeinsights-db/conf:/conf \
     index.docker.io/sourcegraph/postgres-12-alpine:135107_2022-03-03_9498a8bd3366@sha256:e26b159dc7c0c47d136886390c899816e669a3c2c1ead689bdad0b610364e45e
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,


### PR DESCRIPTION
<!-- description here -->
Bind mount the postgres configuration file to allow admins to tune their databases in the pure-docker deployment.

See: https://github.com/sourcegraph/customer/issues/854

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [x] All images have a valid tag and SHA256 sum
### Test plan

Manual testing

### manual test result
**successful creation of mount**
```
docker exec -it pgsql bash -c 'cat /etc/mtab | grep "/conf"'
grpcfuse /conf fuse.grpcfuse rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=1048576 0 0
```

**correct file copied into postgres data dir**
```
docker exec -it pgsql bash -c 'cat /var/lib/postgresql/data/pgdata/postgresql.conf'
#------------------------------------------------------------------------------
# POSTGRESQL DEFAULT CONFIGURATION
#------------------------------------------------------------------------------

# Below is PostgreSQL default configuration.
# You should apply your own customization in the CUSTOMIZED OPTIONS section below
# to avoid merge conflict in the future.

listen_addresses = '*'
max_connections = 100
shared_buffers = 128MB
dynamic_shared_memory_type = posix
max_wal_size = 1GB
min_wal_size = 80MB
log_timezone = 'UTC'
datestyle = 'iso, mdy'
timezone = 'UTC'
lc_messages = 'en_US.utf8'
lc_monetary = 'en_US.utf8'
lc_numeric = 'en_US.utf8'
lc_time = 'en_US.utf8'
default_text_search_config = 'pg_catalog.english'


#------------------------------------------------------------------------------
# SOURCEGRAPH RECOMMENDED OPTIONS
#------------------------------------------------------------------------------

# Below is Sourcegraph recommended Postgres configuration based on the default resource configuration.
# You should apply your own customization in the CUSTOMIZED OPTIONS section below
# to avoid merge conflict in the future.

shared_buffers = 509546kB
work_mem = 3184kB
maintenance_work_mem = 254773kB
effective_io_concurrency = 200
max_worker_processes = 19
max_parallel_workers_per_gather = 4
max_parallel_workers = 8
wal_buffers = 15285kB
min_wal_size = 512MB
checkpoint_completion_target = 0.9
random_page_cost = 1.1
effective_cache_size = 1492MB
default_statistics_target = 500
autovacuum_max_workers = 10
autovacuum_naptime = 10
shared_preload_libraries = ''
max_locks_per_transaction = 64


#------------------------------------------------------------------------------
# CUSTOMIZED OPTIONS
#------------------------------------------------------------------------------

# Add your customization here
# Learn more: https://docs.sourcegraph.com/admin/config/postgres-conf
```

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
