### PR TITLE
all: replace links to sourcegraph master to main

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,4 @@
-# @sourcegraph: This file should be kept in sync with https://github.com/sourcegraph/sourcegraph/blob/master/cmd/server/shared/assets/nginx.conf
+# @sourcegraph: This file should be kept in sync with https://github.com/sourcegraph/sourcegraph/blob/main/cmd/server/shared/assets/nginx.conf
 #
 # You can adjust the configuration to add additional TLS or HTTP features.
 # Read more at https://docs.sourcegraph.com/admin/nginx

--- a/nginx/nginx/sourcegraph_backend.conf
+++ b/nginx/nginx/sourcegraph_backend.conf
@@ -1,4 +1,4 @@
-# @sourcegraph: This file was adapted from https://github.com/sourcegraph/sourcegraph/blob/master/cmd/server/shared/assets/nginx/sourcegraph_backend.conf
+# @sourcegraph: This file was adapted from https://github.com/sourcegraph/sourcegraph/blob/main/cmd/server/shared/assets/nginx/sourcegraph_backend.conf
 #
 # Do not remove. This config is included in the upstream context for backend by
 # nginx.conf

--- a/nginx/nginx/sourcegraph_http.conf
+++ b/nginx/nginx/sourcegraph_http.conf
@@ -1,4 +1,4 @@
-# @sourcegraph: This file should be kept in sync with https://github.com/sourcegraph/sourcegraph/blob/master/cmd/server/shared/assets/nginx/sourcegraph_http.conf
+# @sourcegraph: This file should be kept in sync with https://github.com/sourcegraph/sourcegraph/blob/main/cmd/server/shared/assets/nginx/sourcegraph_http.conf
 #
 # Do not remove. The contents of sourcegraph_http.conf can change between
 # versions and may include improvements to the configuration.

--- a/nginx/nginx/sourcegraph_main.conf
+++ b/nginx/nginx/sourcegraph_main.conf
@@ -1,4 +1,4 @@
-# @sourcegraph: This file should be kept in sync with https://github.com/sourcegraph/sourcegraph/blob/master/cmd/server/shared/assets/nginx/sourcegraph_main.conf
+# @sourcegraph: This file should be kept in sync with https://github.com/sourcegraph/sourcegraph/blob/main/cmd/server/shared/assets/nginx/sourcegraph_main.conf
 #
 # Do not remove. The contents of sourcegraph_main.conf can change between
 # versions and may include improvements to the configuration.

--- a/nginx/nginx/sourcegraph_server.conf
+++ b/nginx/nginx/sourcegraph_server.conf
@@ -1,4 +1,4 @@
-# @sourcegraph: This file should be kept in sync with https://github.com/sourcegraph/sourcegraph/blob/master/cmd/server/shared/assets/nginx/sourcegraph_server.conf
+# @sourcegraph: This file should be kept in sync with https://github.com/sourcegraph/sourcegraph/blob/main/cmd/server/shared/assets/nginx/sourcegraph_server.conf
 #
 # Do not modify. 
 


### PR DESCRIPTION
We no longer use the master branch and one day will delete it.

Test Plan: CI

[_Created by Sourcegraph batch change `keegan/update-master-links`._](https://k8s.sgdev.org/users/keegan/batch-changes/update-master-links)