### PR TITLE
Upgrade caddy

### DIFF
--- a/caddy/builtins/http.Caddyfile
+++ b/caddy/builtins/http.Caddyfile
@@ -4,9 +4,9 @@
 
 :80
 
-reverse_proxy {$SRC_FRONTEND_ADDRESSES}
-
-# If the customer uses a reverse proxy in front of Caddy, 
-# add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
+# Add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
 # More information in https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
-# trusted_proxies: - 
+reverse_proxy {
+	to {$SRC_FRONTEND_ADDRESSES}
+	trusted_proxies 0.0.0.0/0
+}

--- a/caddy/builtins/http.Caddyfile
+++ b/caddy/builtins/http.Caddyfile
@@ -5,3 +5,8 @@
 :80
 
 reverse_proxy {$SRC_FRONTEND_ADDRESSES}
+
+# If the customer uses a reverse proxy in front of Caddy, 
+# add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
+# More information in https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
+# trusted_proxies: - 

--- a/caddy/builtins/https.custom-cert.Caddyfile
+++ b/caddy/builtins/https.custom-cert.Caddyfile
@@ -14,3 +14,8 @@ redir @http https://{host}{uri}
 tls /sourcegraph.pem /sourcegraph.key
 
 reverse_proxy {$SRC_FRONTEND_ADDRESSES}
+
+# If the customer uses a reverse proxy in front of Caddy, 
+# add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
+# More information in https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
+# trusted_proxies: - 

--- a/caddy/builtins/https.custom-cert.Caddyfile
+++ b/caddy/builtins/https.custom-cert.Caddyfile
@@ -1,4 +1,4 @@
-# Serves Sourcegraph over HTTPS, using a custom SSL certificate/key pair 
+# Serves Sourcegraph over HTTPS, using a custom SSL certificate/key pair
 # that's bind mounted from the host to /sourcegraph.pem and /sourcegraph.key.
 #
 # Caddyfile documentation: https://caddyserver.com/docs/caddyfile
@@ -7,15 +7,15 @@
 
 # Redirects all HTTP traffic to HTTPS (using custom SSL certificates disables the automatic HTTPS feature of Caddy, see https://caddyserver.com/docs/automatic-https)
 @http {
-   protocol http
+	protocol http
 }
 redir @http https://{host}{uri}
 
 tls /sourcegraph.pem /sourcegraph.key
 
-reverse_proxy {$SRC_FRONTEND_ADDRESSES}
-
-# If the customer uses a reverse proxy in front of Caddy, 
-# add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
+# Add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
 # More information in https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
-# trusted_proxies: - 
+reverse_proxy {
+	to {$SRC_FRONTEND_ADDRESSES}
+	trusted_proxies 0.0.0.0/0
+}

--- a/caddy/builtins/https.lets-encrypt-prod.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt-prod.Caddyfile
@@ -19,3 +19,8 @@
 {$SRC_SITE_ADDRESS}
 
 reverse_proxy {$SRC_FRONTEND_ADDRESSES}
+
+# If the customer uses a reverse proxy in front of Caddy, 
+# add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
+# More information in https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
+# trusted_proxies: - 

--- a/caddy/builtins/https.lets-encrypt-prod.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt-prod.Caddyfile
@@ -1,26 +1,25 @@
 # Serves Sourcegraph over HTTPS, using Caddy's automatic HTTPS certificate feature:
 # https://caddyserver.com/docs/automatic-https
 #
-# 🚨 Warning: If your DNS and Caddy configuration aren't properly configured (as 
-#             specified in https://caddyserver.com/docs/automatic-https), you can 
-#             run into Let's Encrypt rate limits which can block your certificates 
-#             for up to a week. 
-#             It's strongly recommened that you use the staging Caddyfile 
+# 🚨 Warning: If your DNS and Caddy configuration aren't properly configured (as
+#             specified in https://caddyserver.com/docs/automatic-https), you can
+#             run into Let's Encrypt rate limits which can block your certificates
+#             for up to a week.
+#             It's strongly recommened that you use the staging Caddyfile
 #             (https.lets-encrypt-staging.Caddyfile) to test your
-#             configuration before switching to this production one. 
+#             configuration before switching to this production one.
 #
 # Caddyfile documentation: https://caddyserver.com/docs/caddyfile
 #
-
 {
-    email {$SRC_ACME_EMAIL}
+	email {$SRC_ACME_EMAIL}
 }
 
 {$SRC_SITE_ADDRESS}
 
-reverse_proxy {$SRC_FRONTEND_ADDRESSES}
-
-# If the customer uses a reverse proxy in front of Caddy, 
-# add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
+# Add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
 # More information in https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
-# trusted_proxies: - 
+reverse_proxy {
+	to {$SRC_FRONTEND_ADDRESSES}
+	trusted_proxies 0.0.0.0/0
+}

--- a/caddy/builtins/https.lets-encrypt-staging.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt-staging.Caddyfile
@@ -25,3 +25,8 @@
 {$SRC_SITE_ADDRESS}
 
 reverse_proxy {$SRC_FRONTEND_ADDRESSES}
+
+# If the customer uses a reverse proxy in front of Caddy, 
+# add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
+# More information in https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
+# trusted_proxies: - 

--- a/caddy/builtins/https.lets-encrypt-staging.Caddyfile
+++ b/caddy/builtins/https.lets-encrypt-staging.Caddyfile
@@ -1,32 +1,31 @@
 # Serves Sourcegraph over HTTPS, using Caddy's automatic HTTPS certificate feature:
 # https://caddyserver.com/docs/automatic-https
-# 
-# Note: This configuration uses Let's Encrypt's staging environment. This will 
-# allow you to ensure that everything is correctly configured (with a reduced 
+#
+# Note: This configuration uses Let's Encrypt's staging environment. This will
+# allow you to ensure that everything is correctly configured (with a reduced
 # chance of running into rate limit issues). Note that using this configuration
 # issues a fake certificate (for testing purposes) instead of a trusted one.
 #
-# 🚨 Warning: If your DNS and Caddy configuration aren't properly configured (as 
-#             specified in https://caddyserver.com/docs/automatic-https), you can 
-#             run into Let's Encrypt rate limits which can block your certificates 
-#             for up to a week. 
+# 🚨 Warning: If your DNS and Caddy configuration aren't properly configured (as
+#             specified in https://caddyserver.com/docs/automatic-https), you can
+#             run into Let's Encrypt rate limits which can block your certificates
+#             for up to a week.
 #             It's strongly recommened that you use this Caddyfile to test your
-#             configuration before switching to the production one. 
+#             configuration before switching to the production one.
 #
 # Caddyfile documentation: https://caddyserver.com/docs/caddyfile
 #
-
 {
-    # Use Let's Encrypt's staging environment
-    acme_ca "https://acme-staging-v02.api.letsencrypt.org/directory"
-    email {$SRC_ACME_EMAIL}
+	# Use Let's Encrypt's staging environment
+	acme_ca "https://acme-staging-v02.api.letsencrypt.org/directory"
+	email {$SRC_ACME_EMAIL}
 }
 
 {$SRC_SITE_ADDRESS}
 
-reverse_proxy {$SRC_FRONTEND_ADDRESSES}
-
-# If the customer uses a reverse proxy in front of Caddy, 
-# add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
+# Add the reverse proxies IPs (or IP CIDR ranges) to the trusted_proxies list.
 # More information in https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
-# trusted_proxies: - 
+reverse_proxy {
+	to {$SRC_FRONTEND_ADDRESSES}
+	trusted_proxies 0.0.0.0/0
+}

--- a/caddy/builtins/https.trusted-proxies.Caddyfile
+++ b/caddy/builtins/https.trusted-proxies.Caddyfile
@@ -1,0 +1,3 @@
+# Add customer's reverse proxies IPs (or IP CIDR ranges) to the list.
+# More information in https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
+trusted_proxies: - 

--- a/caddy/builtins/https.trusted-proxies.Caddyfile
+++ b/caddy/builtins/https.trusted-proxies.Caddyfile
@@ -1,3 +1,0 @@
-# Add customer's reverse proxies IPs (or IP CIDR ranges) to the list.
-# More information in https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
-trusted_proxies: - 

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -85,6 +85,9 @@ services:
     volumes:
       - 'caddy:/caddy-storage'
       #
+      # IMPORTANT: if a customer uses a reverse proxy in front of Caddy
+      # the configuration files below must be updated to include trusted_proxies
+      # 
       # Comment out the following line when using HTTPS with either Let's Encrypt or custom certificates
       - '../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile'
       #
@@ -103,10 +106,6 @@ services:
       #
       # Uncomment / update the following line when using HTTPS with custom certificates
       # - '/LOCAL/KEY/PATH.key:/sourcegraph.key'
-      # 
-      # Uncomment / update the following line if Caddy is behind a reverse proxy or load balancer
-      # IMPORTANT: the file below needs to be updated to include customer's ips
-      # - '../caddy/builtins/https.trusted-proxies.Caddyfile'
     ports:
       - '0.0.0.0:80:80'
       - '0.0.0.0:443:443'

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -103,6 +103,10 @@ services:
       #
       # Uncomment / update the following line when using HTTPS with custom certificates
       # - '/LOCAL/KEY/PATH.key:/sourcegraph.key'
+      # 
+      # Uncomment / update the following line if Caddy is behind a reverse proxy or load balancer
+      # IMPORTANT: the file below needs to be updated to include customer's ips
+      # - '../caddy/builtins/https.trusted-proxies.Caddyfile'
     ports:
       - '0.0.0.0:80:80'
       - '0.0.0.0:443:443'

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -70,7 +70,7 @@ services:
   # https://caddyserver.com/docs/caddyfile
   caddy:
     container_name: caddy
-    image: 'index.docker.io/caddy:2.4.6-alpine@sha256:b5a59725783bab0d65803f87028c68dd6611ca6184040bd98b18797cbe26bdd9'
+    image: 'index.docker.io/caddy:2.5.1-alpine@sha256:6e62b63d4d7a4826f9e93c904a0e5b886a8bea2234b6569e300924282a2e8e6c'
     cpus: 4
     mem_limit: '4g'
     environment:


### PR DESCRIPTION
This patches CVE-2021-42377 and CVE-2020-28928.
### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan
* CI checks
* @kevinwojo: I created a GCP compute instance and installed SG with Caddy using HTTPS via LetsEncrypt. I then upgraded Caddy to this latest version. Aside from providing a notice to our customers regarding the new `trusted_proxies` setting, I think this is safe.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
