### PR TITLE
Test failures now correctly fail the build

### DIFF
--- a/pure-docker/deploy-codeinsights-db.sh
+++ b/pure-docker/deploy-codeinsights-db.sh
@@ -12,10 +12,6 @@ set -e
 VOLUME="$HOME/sourcegraph-docker/codeinsights-db-disk"
 ./ensure-volume.sh $VOLUME 999
 
-# Remove timescaledb from the shared_preload_libraries configuration
-# This step can be performed manually instead of run as part of the deploy script
-sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'timescaledb(.*)\'/\1 = '\2'/;s/,'/'/" $VOLUME/pgdata/postgresql.conf
-
 docker run --detach \
     --name=codeinsights-db \
     --network=sourcegraph \

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -10,14 +10,14 @@ deploy_sourcegraph() {
 
 		if [[ "$GIT_BRANCH" == *"customer-replica"* ]]; then
 			# Expected number of containers on e.g. 3.18-customer-replica branch.
-			expect_containers="63"
+			expect_containers="62"
 		else
 			# Expected number of containers on `master` branch.
-			expect_containers="26"
+			expect_containers="25"
 		fi
 	elif [[ "$TEST_TYPE" == "docker-compose-test" ]]; then
 		docker-compose --file docker-compose/docker-compose.yaml up -d
-		expect_containers="26"
+		expect_containers="25"
 	fi
 
 	echo "Giving containers 30s to start..."

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -10,14 +10,14 @@ deploy_sourcegraph() {
 
 		if [[ "$GIT_BRANCH" == *"customer-replica"* ]]; then
 			# Expected number of containers on e.g. 3.18-customer-replica branch.
-			expect_containers="61"
+			expect_containers="63"
 		else
 			# Expected number of containers on `master` branch.
-			expect_containers="25"
+			expect_containers="26"
 		fi
 	elif [[ "$TEST_TYPE" == "docker-compose-test" ]]; then
 		docker-compose --file docker-compose/docker-compose.yaml up -d
-		expect_containers="23"
+		expect_containers="26"
 	fi
 
 	echo "Giving containers 30s to start..."

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -13,11 +13,11 @@ deploy_sourcegraph() {
 			expect_containers="62"
 		else
 			# Expected number of containers on `master` branch.
-			expect_containers="25"
+			expect_containers="26"
 		fi
 	elif [[ "$TEST_TYPE" == "docker-compose-test" ]]; then
 		docker-compose --file docker-compose/docker-compose.yaml up -d
-		expect_containers="25"
+		expect_containers="26"
 	fi
 
 	echo "Giving containers 30s to start..."

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -57,9 +57,9 @@ test_containers() {
 
 catch_errors() {
 	count=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -c -v Up)
-	containers_failing=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -v Up | cut -f 1 -d :)
 	if [[ $count -ne 0 ]]; then
-	    echo 
+            containers_failing=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -v Up | cut -f 1 -d :)
+	    echo
 		for cf in $containers_failing; do
 			echo "$cf is failing. Review the log files uploaded as artefacts to see errors."
 			docker logs -t "$cf" >"$cf".log 2>&1

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -56,7 +56,7 @@ test_containers() {
 }
 
 catch_errors() {
-	count=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -c -v Up) || exit 0
+	count=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -c -v Up)
 	containers_failing=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -v Up | cut -f 1 -d :)
 	if [[ $count -ne 0 ]]; then
 	    echo 

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -13,7 +13,7 @@ deploy_sourcegraph() {
 			expect_containers="62"
 		else
 			# Expected number of containers on `master` branch.
-			expect_containers="26"
+			expect_containers="25"
 		fi
 	elif [[ "$TEST_TYPE" == "docker-compose-test" ]]; then
 		docker-compose --file docker-compose/docker-compose.yaml up -d


### PR DESCRIPTION
When a test failed in this repo, it was incorrectly showing as passed. This PR fixes that issue and also the failing tests that have been introduced since.

Closes https://github.com/sourcegraph/sourcegraph/issues/34305.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Builds fail and report messages to Buildkite - see [this failure](https://buildkite.com/sourcegraph/deploy-sourcegraph-docker/builds/11397). CI passes now.