### PR TITLE
CI Test improvements, fixes

### DIFF
--- a/pure-docker/deploy-caddy.sh
+++ b/pure-docker/deploy-caddy.sh
@@ -32,5 +32,5 @@ docker run --detach \
     -p 0.0.0.0:443:443 \
     -v $VOLUME:/caddy-storage \
     --mount type=bind,source="$(pwd)"/../caddy/builtins/http.Caddyfile,target=/etc/caddy/Caddyfile \
-    index.docker.io/caddy:2.4.6-alpine@sha256:b5a59725783bab0d65803f87028c68dd6611ca6184040bd98b18797cbe26bdd9
+    index.docker.io/caddy:2.5.1-alpine@sha256:6e62b63d4d7a4826f9e93c904a0e5b886a8bea2234b6569e300924282a2e8e6c
 

--- a/pure-docker/deploy-codeinsights-db.sh
+++ b/pure-docker/deploy-codeinsights-db.sh
@@ -12,10 +12,6 @@ set -e
 VOLUME="$HOME/sourcegraph-docker/codeinsights-db-disk"
 ./ensure-volume.sh $VOLUME 999
 
-# Remove timescaledb from the shared_preload_libraries configuration
-# This step can be performed manually instead of run as part of the deploy script
-sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'timescaledb(.*)\'/\1 = '\2'/;s/,'/'/" $VOLUME/pgdata/postgresql.conf
-
 docker run --detach \
     --name=codeinsights-db \
     --network=sourcegraph \

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -56,10 +56,10 @@ test_containers() {
 }
 
 catch_errors() {
-	count=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -c -v Up) || exit 0
-	containers_failing=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -v Up | cut -f 1 -d :)
+	count=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -c -v Up) || true
 	if [[ $count -ne 0 ]]; then
-	    echo 
+            containers_failing=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -v Up | cut -f 1 -d :)
+	    echo
 		for cf in $containers_failing; do
 			echo "$cf is failing. Review the log files uploaded as artefacts to see errors."
 			docker logs -t "$cf" >"$cf".log 2>&1

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -16,7 +16,7 @@ deploy_sourcegraph() {
 			expect_containers="25"
 		fi
 	elif [[ "$TEST_TYPE" == "docker-compose-test" ]]; then
-		docker-compose --file docker-compose/docker-compose.yaml up -d
+		docker-compose --file docker-compose/docker-compose.yaml up -d -t 600
 		expect_containers="26"
 	fi
 

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -41,6 +41,7 @@ test_containers() {
 		containers=$(docker ps --format '{{.Names}}' | xargs -I{} -n1 sh -c "printf '{}: ' && docker inspect --format '{{.State.Status}}' {}")
 		containers_running=$(echo "$containers" | grep -c "running")
 		if [[ "$containers_running" -ne "$expect_containers" ]]; then
+			containers_failing=$(docker ps --format '{{.Names}}:{{.Status}}' | grep -v Up | cut -f 1 -d :)
 			echo "TEST FAILURE: expected $expect_containers containers running, found $containers_running. The following containers are failing: $containers_failing"
 			exit 1
 		fi

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -6,7 +6,7 @@ deploy_sourcegraph() {
 	#Deploy sourcegraph
 	if [[ "$TEST_TYPE" == "pure-docker-test" ]]; then
 		./test/volume-config.sh
-		./pure-docker/deploy.sh
+		timeout 600s ./pure-docker/deploy.sh
 
 		if [[ "$GIT_BRANCH" == *"customer-replica"* ]]; then
 			# Expected number of containers on e.g. 3.18-customer-replica branch.

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -10,14 +10,14 @@ deploy_sourcegraph() {
 
 		if [[ "$GIT_BRANCH" == *"customer-replica"* ]]; then
 			# Expected number of containers on e.g. 3.18-customer-replica branch.
-			expect_containers="61"
+			expect_containers="62"
 		else
 			# Expected number of containers on `master` branch.
 			expect_containers="25"
 		fi
 	elif [[ "$TEST_TYPE" == "docker-compose-test" ]]; then
 		docker-compose --file docker-compose/docker-compose.yaml up -d
-		expect_containers="23"
+		expect_containers="26"
 	fi
 
 	echo "Giving containers 30s to start..."

--- a/test/volume-config.sh
+++ b/test/volume-config.sh
@@ -2,14 +2,6 @@
 
 # Create volume directories.
 cd /deploy-sourcegraph-docker
-echo
-echo "creating deployment for volume directories"
-echo
-./pure-docker/deploy.sh
-echo
-echo "tearing down deployment for volume directories"
-echo
-./pure-docker/teardown.sh
 # Set permissions on volume directories.
 #
 # IMPORTANT: If these change, or a new service is introduced, it must be explicitly called out in


### PR DESCRIPTION
This PR fixes a number of issues:
- When a test failed in this repo, it was incorrectly showing as passing
- Adds a timeout to docker-compose up to prevent infinite builds waiting on the migrator to succeed
- Fixes the failing tests by updating references / container counts / unnecessary commands

There is a problem with the pure-docker tests on the customer-replica branch - when I tried to incorporate these changes as a test, I saw failures in the migrator. I'm going to tackle that as a separate followup.

Closes https://github.com/sourcegraph/sourcegraph/issues/34305.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Builds fail and report messages to Buildkite - see [this failure](https://buildkite.com/sourcegraph/deploy-sourcegraph-docker/builds/11405). CI passes now.