### PR TITLE
Switch to insiders builds

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -554,7 +554,7 @@ services:
   #
   pgsql:
     container_name: pgsql
-    image: 'index.docker.io/sourcegraph/postgres-12-alpine:135107_2022-03-03_9498a8bd3366@sha256:e26b159dc7c0c47d136886390c899816e669a3c2c1ead689bdad0b610364e45e'
+    image: 'index.docker.io/sourcegraph/postgres-12-alpine:insiders@sha256:e8f8d8fda4802e1e9f93441ad15b30045add5ebef200086548c232ee3351ad70'
     cpus: 4
     mem_limit: '4g'
     shm_size: '1g'

--- a/pure-docker/deploy-cadvisor.sh
+++ b/pure-docker/deploy-cadvisor.sh
@@ -31,7 +31,7 @@ sudo docker run --detach \
     --volume=/dev/disk/:/dev/disk:ro \
     --privileged \
     --device=/dev/kmsg \
-    index.docker.io/sourcegraph/cadvisor:3.36.3@sha256:249c573262967979889a186344ba5cc4e8e9186ec4f26c759ce9f8527560da69 \
+    index.docker.io/sourcegraph/cadvisor:insiders@sha256:1759a29488048e22aafc182ee4917b6a72cd0aa76d076139efba4500c6b8d167 \
     --port=8080
 
 echo "Deployed cadvisor"

--- a/pure-docker/deploy-codeinsights-db.sh
+++ b/pure-docker/deploy-codeinsights-db.sh
@@ -23,7 +23,7 @@ docker run --detach \
     -e POSTGRES_USER=postgres \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
-    index.docker.io/sourcegraph/codeinsights-db:3.36.3@sha256:98133abeb1fc6d02ee9f0fca6cc3ab65e2a3a47a07db96a56aa0869389393fce
+    index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:f9ec6c4ad49034945b6257355e38d402235f5a2220ca5a6ba84f154f2366c3e9
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,
 # but anything 12 and higher is supported.

--- a/pure-docker/deploy-codeintel-db.sh
+++ b/pure-docker/deploy-codeintel-db.sh
@@ -19,7 +19,7 @@ docker run --detach \
     --memory=2g \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
-    index.docker.io/sourcegraph/codeintel-db:3.36.3@sha256:fe3e956733e6ad3599c79d8ca8754249281eb3918aab110e99189cc9b052e28a
+    index.docker.io/sourcegraph/codeintel-db:insiders@sha256:56eb2082c96025c83a1b3aba39dd2dfa0730f2213a4a2dba60afeb374c454da9
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,
 # but anything 12 and higher is supported.

--- a/pure-docker/deploy-frontend-internal.sh
+++ b/pure-docker/deploy-frontend-internal.sh
@@ -40,6 +40,6 @@ docker run --detach \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \
     -e PROMETHEUS_URL=http://prometheus:9090 \
     -v $VOLUME:/mnt/cache \
-    index.docker.io/sourcegraph/frontend:3.36.3@sha256:f446e633ea7b536bb1a634267dea2ad1220734e90b7649aa981e9240d39e7e0c
+    index.docker.io/sourcegraph/frontend:insiders@sha256:6660a1fc063bc63ba7a3f8eeca0689d5916b1b1a6c77de29ae9508e7e4d59272
 
 echo "Deployed sourcegraph-frontend-internal service"

--- a/pure-docker/deploy-frontend.sh
+++ b/pure-docker/deploy-frontend.sh
@@ -42,7 +42,7 @@ docker run --detach \
     -e PROMETHEUS_URL=http://prometheus:9090 \
     -v $VOLUME:/mnt/cache \
     -p 0.0.0.0:$((3080 + $1)):3080 \
-    index.docker.io/sourcegraph/frontend:3.36.3@sha256:f446e633ea7b536bb1a634267dea2ad1220734e90b7649aa981e9240d39e7e0c
+    index.docker.io/sourcegraph/frontend:insiders@sha256:6660a1fc063bc63ba7a3f8eeca0689d5916b1b1a6c77de29ae9508e7e4d59272
 
 # Note: SRC_GIT_SERVERS, SEARCHER_URL, and SYMBOLS_URL are space-separated
 # lists which each allow you to specify more container instances for scaling

--- a/pure-docker/deploy-github-proxy.sh
+++ b/pure-docker/deploy-github-proxy.sh
@@ -21,6 +21,6 @@ docker run --detach \
     -e GOMAXPROCS=1 \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST=jaeger \
-    index.docker.io/sourcegraph/github-proxy:3.36.3@sha256:0b8f2a3d5751bf2e438ce1784be5cac7da19bdca0a25623f03a64a652c8def0d
+    index.docker.io/sourcegraph/github-proxy:insiders@sha256:446aa7b5552c80d13077cd1fbf111b74499dbdfc4ac38ade24a6ca8d8999f2fd
 
 echo "Deployed github-proxy service"

--- a/pure-docker/deploy-gitserver.sh
+++ b/pure-docker/deploy-gitserver.sh
@@ -23,6 +23,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST=jaeger \
     -v $VOLUME:/data/repos \
-    index.docker.io/sourcegraph/gitserver:3.36.3@sha256:8830d2bd6a3ad1fefeb9b7e89471101fa8b3e342b5f0a80cb793985b9017f07b
+    index.docker.io/sourcegraph/gitserver:insiders@sha256:04dc254072efc2997e75c2003e5c56e19d03d96d37b7a68de7fd03fee9b83341
 
 echo "Deployed gitserver $1 service"

--- a/pure-docker/deploy-grafana.sh
+++ b/pure-docker/deploy-grafana.sh
@@ -21,7 +21,7 @@ docker run --detach \
     -v $VOLUME:/var/lib/grafana \
     -v $(pwd)/../grafana/datasources:/sg_config_grafana/provisioning/datasources \
     -v $(pwd)/../grafana/dashboards:/sg_grafana_additional_dashboards \
-    index.docker.io/sourcegraph/grafana:3.36.3@sha256:064908bc5848234f2fa4d86f7289af38b707612f90d80008acabe805c27c8a15
+    index.docker.io/sourcegraph/grafana:insiders@sha256:00064d24e19e1159dd70d12bc328db64e8c45fb53062b9b0e3db93984371836d
 
 # Add the following lines above if you wish to use an auth proxy with Grafana:
 #

--- a/pure-docker/deploy-jaeger.sh
+++ b/pure-docker/deploy-jaeger.sh
@@ -20,5 +20,5 @@ docker run --detach \
     -p 0.0.0.0:5778:5778 \
     -p 0.0.0.0:6831:6831 \
     -p 0.0.0.0:6832:6832 \
-    index.docker.io/sourcegraph/jaeger-all-in-one:3.36.3@sha256:c95c0f563dfc946b06ff0ce8c7db6d66e62b09a937917d804828bc46503e517b \
+    index.docker.io/sourcegraph/jaeger-all-in-one:insiders@sha256:5ddf4be454010327b9aa79c33cd447e5fb1ec64e7ad4add9702731dfdd497c6d \
     --memory.max-traces=20000

--- a/pure-docker/deploy-migrator.sh
+++ b/pure-docker/deploy-migrator.sh
@@ -20,7 +20,7 @@ docker run --detach \
     -e CODEINTEL_PGUSER=sg \
     -e CODEINTEL_PGHOST=codeintel-db \
     -e CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@codeinsights-db:5432/postgres \
-    index.docker.io/sourcegraph/migrator:insiders@sha256:38f01f0ac17c04a8c9029444ba9fced0501c6bd75415445c825900efca7bb92c \
+    index.docker.io/sourcegraph/migrator:insiders@sha256:323ad71a75a6a99bd90ada1e1dd135f204f4c00cc81f70c41c5f1bf3d09d0538 \
     up -db=all
 
 echo "Deployed migrator service"

--- a/pure-docker/deploy-minio.sh
+++ b/pure-docker/deploy-minio.sh
@@ -21,5 +21,5 @@ docker run --detach \
     -v $VOLUME:/data \
     -e MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE \
     -e MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
-    index.docker.io/sourcegraph/minio:3.36.3@sha256:66925bab722ed11584e1135687b5c1e00a13c550e38d954a56048c90f17edc53 \
+    index.docker.io/sourcegraph/minio:insiders@sha256:d5377e0c6e4ed742c551f253591d4a1a7f3a104ca17c51d46d6324206577f209 \
     server /data

--- a/pure-docker/deploy-pgsql.sh
+++ b/pure-docker/deploy-pgsql.sh
@@ -19,7 +19,7 @@ docker run --detach \
     --memory=2g \
     -e PGDATA=/var/lib/postgresql/data/pgdata \
     -v $VOLUME:/var/lib/postgresql/data/ \
-    index.docker.io/sourcegraph/postgres-12-alpine:135107_2022-03-03_9498a8bd3366@sha256:e26b159dc7c0c47d136886390c899816e669a3c2c1ead689bdad0b610364e45e
+    index.docker.io/sourcegraph/postgres-12-alpine:insiders@sha256:e8f8d8fda4802e1e9f93441ad15b30045add5ebef200086548c232ee3351ad70
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,
 # but anything 12 and higher is supported.

--- a/pure-docker/deploy-precise-code-intel-worker.sh
+++ b/pure-docker/deploy-precise-code-intel-worker.sh
@@ -15,6 +15,6 @@ docker run --detach \
     --memory=4g \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST=jaeger \
-    index.docker.io/sourcegraph/precise-code-intel-worker:3.36.3@sha256:a5c4622636404fd5d753d11c907cde27676839c46b294bd111c0fb3475a708d9
+    index.docker.io/sourcegraph/precise-code-intel-worker:3.41.0@sha256:2e5c54f47fd05117717a0784487221602099424e6531bca0489c850088d6f7de
 
 echo "Deployed precise-code-intel-worker service"

--- a/pure-docker/deploy-prometheus.sh
+++ b/pure-docker/deploy-prometheus.sh
@@ -21,4 +21,4 @@ docker run --detach \
     -v $VOLUME:/prometheus \
     -v $(pwd)/../prometheus:/sg_prometheus_add_ons \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
-    index.docker.io/sourcegraph/prometheus:3.36.3@sha256:01e102854f9d5888cd961f3aa8af416c2d0336b8673eefd8b2c7a095246fc130
+    index.docker.io/sourcegraph/prometheus:insiders@sha256:b36ad28d24e010cfacb6c21d8b95656f78e2f1cd74ab43fdddfa35b181d9fe39

--- a/pure-docker/deploy-redis-cache.sh
+++ b/pure-docker/deploy-redis-cache.sh
@@ -18,6 +18,6 @@ docker run --detach \
     --cpus=1 \
     --memory=6g \
     -v $VOLUME:/redis-data \
-    index.docker.io/sourcegraph/redis-cache:3.36.3@sha256:4aa9d97e42ad44e035107c12af6605543afb27c5b3b8582721e8c12736129597
+    index.docker.io/sourcegraph/redis-cache:insiders@sha256:b4810d7505d69d29c9b1a9e2f4d6a2ad7287b33ef6c6a92653bb41fa49df958e
 
 echo "Deployed redis-cache service"

--- a/pure-docker/deploy-redis-store.sh
+++ b/pure-docker/deploy-redis-store.sh
@@ -18,6 +18,6 @@ docker run --detach \
     --cpus=1 \
     --memory=6g \
     -v $VOLUME:/redis-data \
-    index.docker.io/sourcegraph/redis-store:3.36.3@sha256:6f33f93d73b825c890f3eb22f9d1f760c92e21b19cc948a9f58921c8eb5bbfc0
+    index.docker.io/sourcegraph/redis-store:insiders@sha256:b585f6b1ad105067b44f633baad0361346782f9b3ee9988d6e85354b0fafc193
 
 echo "Deployed redis-store service"

--- a/pure-docker/deploy-repo-updater.sh
+++ b/pure-docker/deploy-repo-updater.sh
@@ -23,6 +23,6 @@ docker run --detach \
     -e JAEGER_AGENT_HOST=jaeger \
     -e GITHUB_BASE_URL=http://github-proxy:3180 \
     -v $VOLUME:/mnt/cache \
-    index.docker.io/sourcegraph/repo-updater:3.36.3@sha256:e4c2c756a97c15da8c5e4e4b944ca3ed8b469ecb6f284e0bad598c6cbf0d8452
+    index.docker.io/sourcegraph/repo-updater:insiders@sha256:1f500c06ab1ce74e78bf11c283ba1f5cebc2b0460017f8c04f2f695e5ce46b35
 
 echo "Deployed repo-updater service"

--- a/pure-docker/deploy-searcher.sh
+++ b/pure-docker/deploy-searcher.sh
@@ -22,6 +22,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST=jaeger \
     -v $VOLUME:/mnt/cache \
-    index.docker.io/sourcegraph/searcher:3.36.3@sha256:c2ab00f8194fde6eec005bedb4296e86c1262f086e963577f669d480504df016
+    index.docker.io/sourcegraph/searcher:insiders@sha256:688cdaf477a9aab4f06cdddd719a63ac59a8e6477795a3afff3f0f186079cb2f
 
 echo "Deployed searcher $1 service"

--- a/pure-docker/deploy-symbols.sh
+++ b/pure-docker/deploy-symbols.sh
@@ -22,6 +22,6 @@ docker run --detach \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e JAEGER_AGENT_HOST=jaeger \
     -v $VOLUME:/mnt/cache \
-    index.docker.io/sourcegraph/symbols:3.36.3@sha256:6b75d298acdbad333ed33e077a815ffe12b45b7d7ee76438b9b81f61faf6b60b
+    index.docker.io/sourcegraph/symbols:insiders@sha256:61d94f24446303be2222707cfeebfe7e487b2b2e6ec308d22a659434c8b15109
 
 echo "Deployed symbols $1 service"

--- a/pure-docker/deploy-syntect-server.sh
+++ b/pure-docker/deploy-syntect-server.sh
@@ -15,6 +15,6 @@ docker run --detach \
     --restart=always \
     --cpus=4 \
     --memory=6g \
-    index.docker.io/sourcegraph/syntax-highlighter:3.36.3@sha256:d1088ff81f2b700f5541d23a14910b850309ce9208058255816e771be9e1d49b
+    index.docker.io/sourcegraph/syntax-highlighter:insiders@sha256:9a55861de5274a1febe8fd21217304b7fd69afedb85eefa42aa8b17fc28017cb
 
 echo "Deployed syntect-server service"

--- a/pure-docker/deploy-worker.sh
+++ b/pure-docker/deploy-worker.sh
@@ -27,6 +27,6 @@ docker run --detach \
     -e SRC_GIT_SERVERS="$(addresses "gitserver-" $NUM_GITSERVER ":3178")" \
     -e SYMBOLS_URL="$(addresses "http://symbols-" $NUM_SYMBOLS ":3184")" \
     -v $VOLUME:/mnt/cache \
-    index.docker.io/sourcegraph/worker:3.36.3@sha256:b4e56f9f2b1dc6c603463b743aca7da9dfeff83677aa271ace5eacf9e70181b4
+    index.docker.io/sourcegraph/worker:insiders@sha256:db428aa8602142005970708a6211b395c0798cf0b1ef1f40530860990ea2b1f9
 
 echo "Deployed worker service"

--- a/pure-docker/deploy-zoekt-indexserver.sh
+++ b/pure-docker/deploy-zoekt-indexserver.sh
@@ -29,6 +29,6 @@ docker run --detach \
     -e HOSTNAME=zoekt-webserver-$1:6070 \
     -e SRC_FRONTEND_INTERNAL=http://sourcegraph-frontend-internal:3090 \
     -v $VOLUME:/data/index \
-    index.docker.io/sourcegraph/search-indexer:3.36.3@sha256:a9a72e81cacdb644b0530229bd6b5c54dcd84d2d15d11976f28b59f970b85471
+    index.docker.io/sourcegraph/search-indexer:insiders@sha256:55f663b91ae3cd717262961f34f92ab708b88f07f956bbaa98d81393dbc440d0
 
 echo "Deployed zoekt-indexserver $1 service"

--- a/pure-docker/deploy-zoekt-webserver.sh
+++ b/pure-docker/deploy-zoekt-webserver.sh
@@ -22,6 +22,6 @@ docker run --detach \
     -e GOMAXPROCS=16 \
     -e HOSTNAME=zoekt-webserver-$1:6070 \
     -v $VOLUME:/data/index \
-    index.docker.io/sourcegraph/indexed-searcher:3.36.3@sha256:1399fbff116c249d4aec55c2c1e70c23e4617bf3a17921cfdede53893e97b533
+    index.docker.io/sourcegraph/indexed-searcher:insiders@sha256:c7dee54ab00c0ffcdf9baefacb694828d5b42d8d89d39027f3e8076baa7a1616
 
 echo "Deployed zoekt-webserver $1 service"


### PR DESCRIPTION
Renovate isn't updating the pure-docker images because they're tagged with a semver instead of insiders. This PR switches the references back to insiders.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
CI should pass.