### PR TITLE
executors: Add new worker prometheus scrape target

### DIFF
--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -17,6 +17,10 @@
   targets:
     - worker:6060
 - labels:
+    job: worker-executors
+  targets:
+    - worker:6996
+- labels:
     job: node
   targets:
     - syntect-server:6060


### PR DESCRIPTION
This adds a scrape config for a new port exposed by the worker service that serves the collected executor metrics.

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

Will have to test it once https://github.com/sourcegraph/sourcegraph/pull/36969 landed, otherwise we'll revert.