### PR TITLE
otel-collector: bump resources

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -16,8 +16,7 @@ services:
     image: 'index.docker.io/sourcegraph/migrator:169594_2022-08-27_c479e442c579@sha256:c2c517a7bd59197bcabbebe7ea1e02a85dce3a69d5cab7dbbc8a021cbc231041'
     cpus: 0.5
     mem_limit: '500m'
-    command:
-      ["up"]
+    command: ['up']
     environment:
       - PGHOST=pgsql
       - PGPORT=5432
@@ -42,7 +41,7 @@ services:
       - CODEINSIGHTS_PGPASSWORD=password
       - CODEINSIGHTS_PGDATABASE=postgres
       - CODEINSIGHTS_PGSSLMODE=disable
-    restart: "on-failure"
+    restart: 'on-failure'
     networks:
       - sourcegraph
     depends_on:
@@ -87,7 +86,7 @@ services:
       #
       # IMPORTANT: if a customer uses a reverse proxy in front of Caddy
       # the configuration files below must be updated to include trusted_proxies
-      # 
+      #
       # Comment out the following line when using HTTPS with either Let's Encrypt or custom certificates
       - '../caddy/builtins/http.Caddyfile:/etc/caddy/Caddyfile'
       #
@@ -733,8 +732,8 @@ services:
   otel-collector:
     container_name: otel-collector
     image: 'index.docker.io/sourcegraph/opentelemetry-collector:169594_2022-08-27_c479e442c579@sha256:d35ab95bba6604a9f0ba7edbdf209ba5e53c7ad918d7dcb084b8a4603b0e8257'
-    cpus: 0.5
-    mem_limit: '512m'
+    cpus: 1
+    mem_limit: '1g'
     networks:
       - sourcegraph
     restart: always

--- a/pure-docker/deploy-otel-collector.sh
+++ b/pure-docker/deploy-otel-collector.sh
@@ -11,8 +11,8 @@ docker run --detach \
     --name=otel-collector \
     --network=sourcegraph \
     --restart=always \
-    --cpus="0.5" \
-    --memory=512m \
+    --cpus="1" \
+    --memory=1g \
     -e JAEGER_HOST=jaeger \
     -v $(pwd)/../otel-collector/config.yaml:/etc/otel-collector/config.yaml \
     index.docker.io/sourcegraph/opentelemetry-collector:169257_2022-08-25_bb67d3645e59@sha256:a10375336bc505767533b1ec2d32c319e379365e5d6809c1d1dcab1b7fb4798f \


### PR DESCRIPTION
Turns out this can be quite a heavy-duty service - it was recently bumped in S2 (https://github.com/sourcegraph/deploy-sourcegraph-managed/pull/1171), so we make a more modest bump here.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

CI Passes