### PR TITLE
Add GITHUB_BASE_URL to gitserver deployments

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -218,6 +218,7 @@ services:
     environment:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
       - 'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317'
+      - 'GITHUB_BASE_URL=http://github-proxy:3180'
     volumes:
       - 'gitserver-0:/data/repos'
     networks:

--- a/pure-docker/deploy-gitserver.sh
+++ b/pure-docker/deploy-gitserver.sh
@@ -22,6 +22,7 @@ docker run --detach \
     -e GOMAXPROCS=4 \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
     -e 'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317' \
+    -e 'GITHUB_BASE_URL=http://github-proxy:3180' \
     -v $VOLUME:/data/repos \
     index.docker.io/sourcegraph/gitserver:3.43.0@sha256:b3192b3fdc59fccc80c9d3e6bb2be38c0ca1474281fce09e89f664d07aa8f2ae
 


### PR DESCRIPTION
<!-- description here -->

Adds the GITHUB_BASE_URL environment variable to gitserver deployments.

For GitHub App to function, gitserver needs to periodically refresh the access token through github-proxy.

The end goal here is to have this change propagate to this file: https://github.com/sourcegraph/deploy-sourcegraph-managed/blob/main/golden/docker-compose.latest.yaml

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: Not sure if this one is necessary? I don't see any mention of `GITHUB_BASE_URL` in this repository
* [ ] All images have a valid tag and SHA256 sum
### Test plan

None yet

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
