### PR TITLE
Update tags for 4.0 release

### DIFF
--- a/docker-compose/db-only-migrate.docker-compose.yaml
+++ b/docker-compose/db-only-migrate.docker-compose.yaml
@@ -13,7 +13,7 @@ services:
   #
   pgsql:
     container_name: pgsql
-    image: 'index.docker.io/sourcegraph/postgres-12-alpine:169594_2022-08-27_c479e442c579@sha256:dc6528d1e17da72d5fd1a20fbcdbf223558906db996df644461974ff3c309a50'
+    image: 'index.docker.io/sourcegraph/postgres-12-alpine:4.0.0@sha256:92f25097760f4293807c8570534b655361fb1643c0ff6ecb73e413be1a857dcc'
     cpus: 4
     mem_limit: '2g'
     healthcheck:
@@ -30,7 +30,7 @@ services:
 
   codeintel-db:
     container_name: codeintel-db
-    image: 'index.docker.io/sourcegraph/codeintel-db:169594_2022-08-27_c479e442c579@sha256:74f76cbaa40ee7195fa3fbb55a01c597a131853236f14d1c0b1d26bd913c9c96'
+    image: 'index.docker.io/sourcegraph/codeintel-db:4.0.0@sha256:7454dfcda25c58eebc4b92f99ea821000f244945fa76c7f8177c2e565cf840c0'
     cpus: 4
     mem_limit: '2g'
     healthcheck:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
   # for this container will need to be updated to reflect the new connection information.
   migrator:
     container_name: migrator
-    image: 'index.docker.io/sourcegraph/migrator:169594_2022-08-27_c479e442c579@sha256:c2c517a7bd59197bcabbebe7ea1e02a85dce3a69d5cab7dbbc8a021cbc231041'
+    image: 'index.docker.io/sourcegraph/migrator:4.0.0@sha256:d09d03f5a046629dc57d66b3d764a10f6b709e110c694d6d0f8afeda622b5191'
     cpus: 0.5
     mem_limit: '500m'
     command: ['up']
@@ -124,7 +124,7 @@ services:
   # service.
   sourcegraph-frontend-0:
     container_name: sourcegraph-frontend-0
-    image: 'index.docker.io/sourcegraph/frontend:169594_2022-08-27_c479e442c579@sha256:69e0e8142e3ede85e4dcb04e693b3a64d2c5fe28286ea2ce6877f6d324eee178'
+    image: 'index.docker.io/sourcegraph/frontend:4.0.0@sha256:2bb90bd8f0be48e21578144917b088d0bb5ba478003a42e88e8087488eee63f4'
     cpus: 4
     mem_limit: '8g'
     environment:
@@ -166,7 +166,7 @@ services:
   #
   sourcegraph-frontend-internal:
     container_name: sourcegraph-frontend-internal
-    image: 'index.docker.io/sourcegraph/frontend:169594_2022-08-27_c479e442c579@sha256:69e0e8142e3ede85e4dcb04e693b3a64d2c5fe28286ea2ce6877f6d324eee178'
+    image: 'index.docker.io/sourcegraph/frontend:4.0.0@sha256:2bb90bd8f0be48e21578144917b088d0bb5ba478003a42e88e8087488eee63f4'
     cpus: 4
     mem_limit: '8g'
     environment:
@@ -212,7 +212,7 @@ services:
   #
   gitserver-0:
     container_name: gitserver-0
-    image: 'index.docker.io/sourcegraph/gitserver:169594_2022-08-27_c479e442c579@sha256:c69f43ff5afa11b5d54d4b4f18e2bd88069f2bc7da3f9d885591c5afa60b5e38'
+    image: 'index.docker.io/sourcegraph/gitserver:4.0.0@sha256:f35ae3373018235ce2982122b6a7fed4c17f5fa6e1231c5480b67a8d63bc42b6'
     cpus: 4
     mem_limit: '8g'
     environment:
@@ -236,7 +236,7 @@ services:
   #
   zoekt-indexserver-0:
     container_name: zoekt-indexserver-0
-    image: 'index.docker.io/sourcegraph/search-indexer:169594_2022-08-27_c479e442c579@sha256:11daea37bdd626d90dd69abf1cc612ddb7d5621c6c738fc39545b870062807b6'
+    image: 'index.docker.io/sourcegraph/search-indexer:4.0.0@sha256:a39b880b28eac8f626b808cdadddfe57bf3e422f59ab8c6bba06344e100a8d99'
     cpus: 8
     mem_limit: '16g'
     environment:
@@ -259,7 +259,7 @@ services:
   #
   zoekt-webserver-0:
     container_name: zoekt-webserver-0
-    image: 'index.docker.io/sourcegraph/indexed-searcher:169594_2022-08-27_c479e442c579@sha256:6bff1cb93d9be8dbe55bbdde30d39a4e9ecd28032046401fcad45bb305cc1d51'
+    image: 'index.docker.io/sourcegraph/indexed-searcher:4.0.0@sha256:e390f54c2662889a5d38a9069ee50b8ca4bb937bbfdb06c4bf30dce49d3e71d1'
     cpus: 8
     mem_limit: '50g'
     environment:
@@ -286,7 +286,7 @@ services:
   #
   searcher-0:
     container_name: searcher-0
-    image: 'index.docker.io/sourcegraph/searcher:169594_2022-08-27_c479e442c579@sha256:99cd1750f87a482f15f6d8b1796f8ad85c79f37baba5fab962d493dd37414a96'
+    image: 'index.docker.io/sourcegraph/searcher:4.0.0@sha256:7aa7f6cc8800c173e92ee181a51708e43abc2b3e29f3631dcc18fa1d69e8dcb3'
     cpus: 2
     mem_limit: '2g'
     environment:
@@ -313,7 +313,7 @@ services:
   #
   github-proxy:
     container_name: github-proxy
-    image: 'index.docker.io/sourcegraph/github-proxy:169594_2022-08-27_c479e442c579@sha256:744f82b83edf65e8d47fdeb3a58039464ce855ae9a0cc5c1ccf989cda2245fe7'
+    image: 'index.docker.io/sourcegraph/github-proxy:4.0.0@sha256:f522aeefe2e13e7592ddbd82c35d1c4e45e024afb9e9433af0fa44c770b3aec6'
     cpus: 1
     mem_limit: '1g'
     environment:
@@ -330,7 +330,7 @@ services:
   #
   precise-code-intel-worker:
     container_name: precise-code-intel-worker
-    image: 'index.docker.io/sourcegraph/precise-code-intel-worker:169594_2022-08-27_c479e442c579@sha256:f5d0eff3bcaa72dfd9e0c7f88829ff0dc27580a875338c68ecd83393884db510'
+    image: 'index.docker.io/sourcegraph/precise-code-intel-worker:4.0.0@sha256:5cd057f3b54c82c8a99e4cedc7a26760702d9d41cf5aa10d1fec7b135f9ba042'
     cpus: 2
     mem_limit: '4g'
     environment:
@@ -354,7 +354,7 @@ services:
   #
   repo-updater:
     container_name: repo-updater
-    image: 'index.docker.io/sourcegraph/repo-updater:169594_2022-08-27_c479e442c579@sha256:87bd2e66cb3b3eb6b8e6b647dc956697e49060009051a4db35dd19ee2146298f'
+    image: 'index.docker.io/sourcegraph/repo-updater:4.0.0@sha256:b4d339e97d97abe4f23d5875d9257dcd2db357b2826216c4a8c86513e79729ff'
     cpus: 4
     mem_limit: '4g'
     environment:
@@ -375,7 +375,7 @@ services:
   #
   worker:
     container_name: worker
-    image: 'index.docker.io/sourcegraph/worker:169594_2022-08-27_c479e442c579@sha256:7c0504e41595cc5ad37a7f42ce5a064edffee4a5772fe4bb56f32827def275f7'
+    image: 'index.docker.io/sourcegraph/worker:4.0.0@sha256:c50482e3a708ac1a73b7e973b1d1f4ca1971f1ca0470e138bc56ba19d7a85f6f'
     cpus: 4
     mem_limit: '4g'
     environment:
@@ -400,7 +400,7 @@ services:
   #
   syntect-server:
     container_name: syntect-server
-    image: 'index.docker.io/sourcegraph/syntax-highlighter:169594_2022-08-27_c479e442c579@sha256:9c467fef15220c3d4ca04dc3bcd25d7fba90105ac40c9d4f1b5a71bfe4f3e646'
+    image: 'index.docker.io/sourcegraph/syntax-highlighter:4.0.0@sha256:83486825d9bc125b574638c57b3a793879607e14b697cbe8721f720a60725fc7'
     cpus: 4
     mem_limit: '6g'
     healthcheck:
@@ -421,7 +421,7 @@ services:
   #
   symbols-0:
     container_name: symbols-0
-    image: 'index.docker.io/sourcegraph/symbols:169594_2022-08-27_c479e442c579@sha256:7bbbcfd4fced793243caa301e3ea60eba255c69c100b38f9707f02a6cd558f59'
+    image: 'index.docker.io/sourcegraph/symbols:4.0.0@sha256:9bdb78de11025ba0186e8212dc87ccf748e344a9a1a7e398b24216b6c069f879'
     cpus: 2
     mem_limit: '4g'
     environment:
@@ -447,7 +447,7 @@ services:
   #
   prometheus:
     container_name: prometheus
-    image: 'index.docker.io/sourcegraph/prometheus:169594_2022-08-27_c479e442c579@sha256:33bbe6f2b59a74f2046df1514c789f204b8cf36edd303c803688fedd9f198604'
+    image: 'index.docker.io/sourcegraph/prometheus:4.0.0@sha256:0e6b30c4fc5a7ab4466d3d81e2547e1845a6bbb1069abf0d9341b999b4912df0'
     cpus: 4
     mem_limit: '8g'
     volumes:
@@ -474,7 +474,7 @@ services:
   # 'GF_SERVER_ROOT_URL='https://grafana.example.com'
   grafana:
     container_name: grafana
-    image: 'index.docker.io/sourcegraph/grafana:169594_2022-08-27_c479e442c579@sha256:e703eef8f4dd348a257d085b53e0d9a3431bc8a26334992eae267a5c8ee5beca'
+    image: 'index.docker.io/sourcegraph/grafana:4.0.0@sha256:f8e485d4f4fe2f85d9bca5c331968e5d05407941923754ddeb4d9ce84c708e90'
     cpus: 1
     mem_limit: '1g'
     volumes:
@@ -495,7 +495,7 @@ services:
   #
   cadvisor:
     container_name: cadvisor
-    image: 'index.docker.io/sourcegraph/cadvisor:169594_2022-08-27_c479e442c579@sha256:2c3aa40297a5206f4c2d502305a2325148314c0e699f1a5696d95b5b28bc6029'
+    image: 'index.docker.io/sourcegraph/cadvisor:4.0.0@sha256:582905d5f6bcddfbd96c0d83da70000307ce8231316704a962fc5ee29a7047af'
     cpus: 1
     mem_limit: '1g'
     # You may set `privileged` to `false and `cadvisor` will run with reduced privileges.
@@ -528,7 +528,7 @@ services:
   #
   pgsql:
     container_name: pgsql
-    image: 'index.docker.io/sourcegraph/postgres-12-alpine:169594_2022-08-27_c479e442c579@sha256:dc6528d1e17da72d5fd1a20fbcdbf223558906db996df644461974ff3c309a50'
+    image: 'index.docker.io/sourcegraph/postgres-12-alpine:4.0.0@sha256:92f25097760f4293807c8570534b655361fb1643c0ff6ecb73e413be1a857dcc'
     cpus: 4
     mem_limit: '4g'
     shm_size: '1g'
@@ -556,7 +556,7 @@ services:
   # for this container will need to be updated to reflect the new connection information.
   pgsql-exporter:
     container_name: pgsql-exporter
-    image: 'index.docker.io/sourcegraph/postgres_exporter:169594_2022-08-27_c479e442c579@sha256:bdf3289b0d7c2ac648922a8998fe15b995cd6dbf2c58898eeab4881bcc27f665'
+    image: 'index.docker.io/sourcegraph/postgres_exporter:4.0.0@sha256:4787d412f8e0a8a6ae60e542837c4bb17811a67ea4b0093c72d70f67e1117120'
     cpus: 0.1
     mem_limit: '50m'
     networks:
@@ -575,7 +575,7 @@ services:
   #
   codeintel-db:
     container_name: codeintel-db
-    image: 'index.docker.io/sourcegraph/codeintel-db:169594_2022-08-27_c479e442c579@sha256:74f76cbaa40ee7195fa3fbb55a01c597a131853236f14d1c0b1d26bd913c9c96'
+    image: 'index.docker.io/sourcegraph/codeintel-db:4.0.0@sha256:7454dfcda25c58eebc4b92f99ea821000f244945fa76c7f8177c2e565cf840c0'
     cpus: 4
     mem_limit: '4g'
     shm_size: '1g'
@@ -603,7 +603,7 @@ services:
   # for this container will need to be updated to reflect the new connection information.
   codeintel-db-exporter:
     container_name: codeintel-db-exporter
-    image: 'index.docker.io/sourcegraph/postgres_exporter:169594_2022-08-27_c479e442c579@sha256:bdf3289b0d7c2ac648922a8998fe15b995cd6dbf2c58898eeab4881bcc27f665'
+    image: 'index.docker.io/sourcegraph/postgres_exporter:4.0.0@sha256:4787d412f8e0a8a6ae60e542837c4bb17811a67ea4b0093c72d70f67e1117120'
     cpus: 0.1
     mem_limit: '50m'
     networks:
@@ -622,7 +622,7 @@ services:
   #
   codeinsights-db:
     container_name: codeinsights-db
-    image: 'index.docker.io/sourcegraph/codeinsights-db:169594_2022-08-27_c479e442c579@sha256:9ffd651428394c0589cb81b131f394efcd16e86e5f9f757215e26dbc3b4f7782'
+    image: 'index.docker.io/sourcegraph/codeinsights-db:4.0.0@sha256:bd496ecf08e3fefda55ea8ba71cfbe77d0470ffea52c34ac800ea9de2702b469'
     cpus: 4
     mem_limit: '2g'
     shm_size: '1g'
@@ -655,7 +655,7 @@ services:
   # for this container will need to be updated to reflect the new connection information.
   codeinsights-db-exporter:
     container_name: codeinsights-db-exporter
-    image: 'index.docker.io/sourcegraph/postgres_exporter:169594_2022-08-27_c479e442c579@sha256:bdf3289b0d7c2ac648922a8998fe15b995cd6dbf2c58898eeab4881bcc27f665'
+    image: 'index.docker.io/sourcegraph/postgres_exporter:4.0.0@sha256:4787d412f8e0a8a6ae60e542837c4bb17811a67ea4b0093c72d70f67e1117120'
     cpus: 0.1
     mem_limit: '50m'
     networks:
@@ -674,7 +674,7 @@ services:
   #
   minio:
     container_name: minio
-    image: 'index.docker.io/sourcegraph/minio:169594_2022-08-27_c479e442c579@sha256:50319e1de1b733fac50aeabc470a6dc0cd827ffd6e6bee0d094494f0bce28ac6'
+    image: 'index.docker.io/sourcegraph/minio:4.0.0@sha256:a8cc7269c2ffecc7c03791d3999ccc30635e5af36cc73e412bec2ac944be7006'
     cpus: 1
     mem_limit: '1g'
     environment:
@@ -701,7 +701,7 @@ services:
   #
   redis-cache:
     container_name: redis-cache
-    image: 'index.docker.io/sourcegraph/redis-cache:169594_2022-08-27_c479e442c579@sha256:1478a27af2091f22e60f217abac439b5fd35a4a2ce980d526929dbca1298df54'
+    image: 'index.docker.io/sourcegraph/redis-cache:4.0.0@sha256:4169f8d15ed363470608850d2c7be87500d25cb6ea56c288e010d1499303d329'
     cpus: 1
     mem_limit: '7g'
     volumes:
@@ -717,7 +717,7 @@ services:
   #
   redis-store:
     container_name: redis-store
-    image: 'index.docker.io/sourcegraph/redis-store:169594_2022-08-27_c479e442c579@sha256:0232949166a4fb1aba519ea14e0917c53493a950a5a75f10af81d4557c7a15b2'
+    image: 'index.docker.io/sourcegraph/redis-store:4.0.0@sha256:bde1d1ee9e9ca68763035cb659d255d67b460321de5c5cb7d05c53f1623e5aa7'
     cpus: 1
     mem_limit: '7g'
     volumes:
@@ -732,7 +732,7 @@ services:
   # Ports exposed to the public internet: none
   otel-collector:
     container_name: otel-collector
-    image: 'index.docker.io/sourcegraph/opentelemetry-collector:169594_2022-08-27_c479e442c579@sha256:d35ab95bba6604a9f0ba7edbdf209ba5e53c7ad918d7dcb084b8a4603b0e8257'
+    image: 'index.docker.io/sourcegraph/opentelemetry-collector:4.0.0@sha256:349bca57f486365fe545371ada8aabb4eaaeca899b829fb8717882ffaea28c19'
     cpus: 1
     mem_limit: '1g'
     networks:

--- a/docker-compose/jaeger/docker-compose.yaml
+++ b/docker-compose/jaeger/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
   #
   jaeger:
     container_name: jaeger
-    image: 'index.docker.io/sourcegraph/jaeger-all-in-one:169594_2022-08-27_c479e442c579@sha256:eed16144aada80f20e72c86c67ed89ba3aca109cfac25f4fe68b7fc9a0588414'
+    image: 'index.docker.io/sourcegraph/jaeger-all-in-one:4.0.0@sha256:2d754d178f7f00896601dba78223af49d148619873e681a4d7deb54279d1f892'
     cpus: 0.5
     mem_limit: '512m'
     ports:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/sourcegraph/deploy-sourcegraph-docker
 go 1.15
 
 require (
-	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220511200824-abaeea3fde03
+	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220922183713-4ab710dc0025
 	github.com/sourcegraph/update-docker-tags v0.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-2022050400313
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220504003139-e2e91f0dcdc9/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220511200824-abaeea3fde03 h1:z1RPRG2xMvrTbRdoDZKuexpg9KSnvQ7RKWu1f8HcWbw=
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220511200824-abaeea3fde03/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220922183713-4ab710dc0025 h1:DVHm16IbByMG0t9vu3hbSabb5AMNND48IOQrnTgCMYk=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220922183713-4ab710dc0025/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
 github.com/sourcegraph/update-docker-tags v0.9.0 h1:FeqPS1GH5n4KyTha/SpZvDDmrdS4c+N8cQ3xb4Rlb+A=
 github.com/sourcegraph/update-docker-tags v0.9.0/go.mod h1:lCDsoUnk/ASDbm7UxE7tU3qAUhQxA7xykELHXcLeKFM=
 github.com/sourcegraph/update-docker-tags v0.10.0 h1:KpY1HtvSt0FzDM/sR0jQF5StNbiPKpqmHhE0jpBEa0A=


### PR DESCRIPTION
A recent change caused the `update-docker-tags.sh` script to only run on the `./pure-docker` subdirectory, but we also want to run it against the `./docker-compose` subdirectory. Will make a separate PR to update the script to run against both, but the is the result of running `go run ./tools/enforce-tags/ "4.0.0" ./docker-compose` manually.

I cherry-picked Coury's commit on `master` that updates the pinned version so we also update the otel images.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

Manually verified that the tags in `docker-compose.yaml` are now populated correctly

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
