### PR TITLE
Update script to also run on ./docker-compose subdirectory

### DIFF
--- a/tools/update-docker-tags.sh
+++ b/tools/update-docker-tags.sh
@@ -8,3 +8,4 @@ cd "$root_dir"
 CONSTRAINT=$1
 
 go run ./tools/enforce-tags "$CONSTRAINT" ./pure-docker
+go run ./tools/enforce-tags "$CONSTRAINT" ./docker-compose


### PR DESCRIPTION
It looks like this was changed in 6d8ecf323dfb7857 to only run on `./pure-docker` when that was moved to a subdirectory, but that causes the images tags in `./docker-compose` to no longer be updated by this script.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

Ran this manually in https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/857

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
