### PR TITLE
prometheus: add zoekt-webserver scrape target

### DIFF
--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -34,6 +34,10 @@
   targets:
     - zoekt-indexserver-0:6072
 - labels:
+    job: zoekt-webserver
+  targets:
+    - zoekt-webserver-0:6070
+- labels:
     job: sourcegraph-frontend
   targets:
     - sourcegraph-frontend-0:6060


### PR DESCRIPTION
for whatever reason, this wasn't in our prometheus configuration already

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: Unnecessary since the k8s Prometheus configuration doesn't manually list scrape targets: https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/prometheus/prometheus.ConfigMap.yaml
### Test plan

Run docker-compose locally, navigate to the Prometheus instance `localhost:9090`, see that `zoekt-webserver` is listed as one of the targets under `localhost:9090/targets`


