### PR TITLE
dev: add helper run.sh script

### DIFF
--- a/docker-compose/dev/README.md
+++ b/docker-compose/dev/README.md
@@ -3,13 +3,18 @@
 For use developing Sourcegraph's docker-compose deployment only.
 For deployments, refer to the official [Sourcegraph with Docker Compose](https://docs.sourcegraph.com/admin/install/docker-compose) documentation.
 
+This folder includes a helper script, [run.sh](./run.sh), that will run the `docker` command (with any provided arguments) while automatically specifying the appropriate set of overlays.
+
 Example usage:
 
 ```sh
-docker-compose \
-    -f docker-compose/docker-compose.yaml \
-    -f docker-compose/jaeger/docker-compose.yaml \
-    -f docker-compose/dev/docker-compose.yaml up
+./run.sh up -d 
 ```
 
 The above will deploy Sourcegraph on [http://localhost:8080](http://localhost:8080) with the indicated overlays.
+
+```sh
+./run.sh down
+```
+
+The above will tear down the local Sourcegraph instance that was set up using the previous command.

--- a/docker-compose/dev/README.md
+++ b/docker-compose/dev/README.md
@@ -3,7 +3,7 @@
 For use developing Sourcegraph's docker-compose deployment only.
 For deployments, refer to the official [Sourcegraph with Docker Compose](https://docs.sourcegraph.com/admin/install/docker-compose) documentation.
 
-This folder includes a helper script, [run.sh](./run.sh), that will run the `docker` command (with any provided arguments) while automatically specifying the appropriate set of overlays.
+This folder includes a helper script, [run.sh](./run.sh), that will run the `docker-compose` command (with any provided arguments) while automatically specifying the appropriate set of overlays.
 
 Example usage:
 

--- a/docker-compose/dev/run.sh
+++ b/docker-compose/dev/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+set -euxo pipefail
+
+docker-compose \
+    -f docker-compose/docker-compose.yaml \
+    -f docker-compose/jaeger/docker-compose.yaml \
+    -f docker-compose/dev/docker-compose.yaml \
+    "$@"


### PR DESCRIPTION
This PR adds a little helper script that helps you run our docker-compose configuration in a development context. Now, we no longer have to copy-paste the correct set of overlays for every `docker` command that we want to run.

### Test plan

This change only modifies the developer tooling for the repo, and doesn't touch any of the production facing docker-compose configurations.
