### PR TITLE
Reduce container count for pure-docker tests

### DIFF
--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -10,7 +10,7 @@ deploy_sourcegraph() {
 
 		if [[ "$GIT_BRANCH" == *"customer-replica"* ]]; then
 			# Expected number of containers on e.g. 3.18-customer-replica branch.
-			expect_containers="62"
+			expect_containers="60"
 		else
 			# Expected number of containers on `master` branch.
 			expect_containers="25"


### PR DESCRIPTION
Adding up the number of expected containers in `./pure-docker/deploy.sh` comes out to 60, which is what the tests are coming up with too. 

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

Tests already yielded this number.