### PR TITLE
ci: increase timeout, volume permissions

### DIFF
--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -20,8 +20,8 @@ deploy_sourcegraph() {
 		expect_containers="26"
 	fi
 
-	echo "Giving containers 30s to start..."
-	sleep 30
+	echo "Giving containers 90s to start..."
+	sleep 90
 }
 
 test_count() {

--- a/test/volume-config.sh
+++ b/test/volume-config.sh
@@ -2,6 +2,14 @@
 
 # Create volume directories.
 cd /deploy-sourcegraph-docker
+echo
+echo "creating deployment for volume directories"
+echo
+./pure-docker/deploy.sh
+echo
+echo "tearing down deployment for volume directories"
+echo
+./pure-docker/teardown.sh
 # Set permissions on volume directories.
 #
 # IMPORTANT: If these change, or a new service is introduced, it must be explicitly called out in
@@ -13,6 +21,7 @@ pushd ~/sourcegraph-docker
 chown -R 100:101 gitserver* prometheus-v2* worker* repo-updater* searcher* sourcegraph-frontend* symbols* zoekt* minio-disk
 chown -R 999:1000 redis-store-disk redis-cache-disk
 chown -R 472:472 grafana-disk
-chown -R 999:999 pgsql-disk codeintel-db-disk codeinsights-db-disk
+chown -R 999:999 pgsql-disk codeintel-db-disk
+chown -R 70:70 codeinsights-db-disk
 popd
 echo "Ready to deploy"


### PR DESCRIPTION
Increase the timeout for containers to start. This is required for customer-replica branches where frontend containers sometimes require more time to start due to database connections. 

This also re-adds the volume setup which was previously removed ( I believe in error). This is required to ensure the volumes exist on disk, then the correct permissions to the directories on disk are applied. 

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

Green tests on this PR
