### PR TITLE
docker-compose: add node exporter deployment

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -520,6 +520,35 @@ services:
     command:
       - --port=8080
 
+  # Description: Publishes Prometheus metrics about the machine's hardware / operating system.
+  #
+  # Disk: none
+  # Ports exposed to other Sourcegraph services: 9100/TCP
+  # Ports exposed to the public internet: none
+  #
+  node-exporter:
+    container_name: node-exporter
+    image: 'index.docker.io/sourcegraph/node-exporter:181368_2022-11-03_bf1f156a4692@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f'
+    cpus: .5
+    mem_limit: '1g'
+    pid: 'host'
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--no-collector.wifi'
+      - '--no-collector.hwmon'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    expose:
+      - 9100
+    networks:
+      - sourcegraph
+    restart: always
+
   # Description: PostgreSQL database for various data.
   #
   # Disk: 128GB / persistent SSD

--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -1,75 +1,98 @@
 ---
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: node
   targets:
     - cadvisor:8080
     - sourcegraph-frontend-internal:6060
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: github-proxy
   targets:
     - github-proxy:6060
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: repo-updater
   targets:
     - repo-updater:6060
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: worker
   targets:
     - worker:6060
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: worker-executors
   targets:
     - worker:6996
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: node
   targets:
     - syntect-server:6060
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: precise-code-intel-worker
   targets:
     - precise-code-intel-worker:6060
     # Add new entries here for every searcher/symbol/gitserver replica.
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: zoekt-indexserver
   targets:
     - zoekt-indexserver-0:6072
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: zoekt-webserver
   targets:
     - zoekt-webserver-0:6070
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: sourcegraph-frontend
   targets:
     - sourcegraph-frontend-0:6060
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: gitserver
   targets:
     - gitserver-0:6060
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: searcher
   targets:
     - searcher-0:6060
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: symbols
   targets:
     - symbols-0:6060
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: pgsql
   targets:
     - pgsql-exporter:9187
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: codeintel-db
   targets:
     - codeintel-db-exporter:9187
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: codeinsights-db
   targets:
     - codeinsights-db-exporter:9187
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: redis-cache
   targets:
     - redis-cache:9121
 - labels:
+    nodename: "sourcegraph-docker-compose-host"
     job: redis-store
   targets:
     - redis-store:9121
+- labels:
+    nodename: "sourcegraph-docker-compose-host"
+    job: node-exporter
+  targets:
+    - node-exporter:9100

--- a/pure-docker/deploy-node-exporter.sh
+++ b/pure-docker/deploy-node-exporter.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+source ./replicas.sh
+
+# Description: Publishes Prometheus metrics about the machine's hardware / operating system.
+#
+# Disk: none
+# Ports exposed to other Sourcegraph services: 9100/TCP
+# Ports exposed to the public internet: none
+#
+sudo docker run --detach \
+    --name=node-exporter \
+    --network=sourcegraph \
+    --restart=always \
+    --cpus=0.5 \
+    --memory=1g \
+    --pid='host' \
+    --volume=/:/rootfs:ro \
+    --volume=/proc:/host/proc:ro \
+    --volume=/sys:/host/sys:ro \
+    -p 0.0.0.0:9100:9100 \
+    index.docker.io/sourcegraph/node-exporter:181368_2022-11-03_bf1f156a4692@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f \
+    '--path.procfs=/host/proc' \
+    '--path.rootfs=/rootfs' \
+    '--path.sysfs=/host/sys' \
+    '--no-collector.wifi' \
+    '--no-collector.hwmon' \
+    '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+
+echo "Deployed node-exporter"

--- a/pure-docker/deploy.sh
+++ b/pure-docker/deploy.sh
@@ -10,6 +10,7 @@ source ./replicas.sh
 
 docker network create sourcegraph &>/dev/null || true
 
+./deploy-node-exporter.sh
 ./deploy-cadvisor.sh
 ./deploy-github-proxy.sh
 for i in $(seq 0 $(($NUM_GITSERVER - 1))); do ./deploy-gitserver.sh $i; done

--- a/pure-docker/teardown.sh
+++ b/pure-docker/teardown.sh
@@ -7,31 +7,31 @@ cd "$root_dir"
 source ./replicas.sh
 
 docker rm -f node-exporter &>/dev/null || true &
-docker rm -f cadvisor &>/dev/null || true &
-docker rm -f caddy &>/dev/null || true &
-docker rm -f sourcegraph-frontend-internal &>/dev/null || true &
-docker rm -f $(addresses "sourcegraph-frontend-" $NUM_FRONTEND "") &>/dev/null || true &
-docker rm -f github-proxy &>/dev/null || true &
-docker rm -f $(addresses "gitserver-" $NUM_GITSERVER "") &>/dev/null || true &
-docker rm -f grafana &>/dev/null || true
-docker rm -f jaeger &>/dev/null || true
-docker rm -f precise-code-intel-worker &>/dev/null || true
-docker rm -f pgsql &>/dev/null || true &
-docker rm -f codeintel-db &>/dev/null || true &
-docker rm -f codeinsights-db &>/dev/null || true &
-docker rm -f minio &>/dev/null || true &
-docker rm -f migrator &>/dev/null || true &
-docker rm -f prometheus &>/dev/null || true
-docker rm -f redis-cache &>/dev/null || true &
-docker rm -f redis-store &>/dev/null || true &
-docker rm -f repo-updater &>/dev/null || true &
-docker rm -f worker &>/dev/null || true &
-docker rm -f $(addresses "searcher-" $NUM_SEARCHER "") &>/dev/null || true &
-docker rm -f $(addresses "symbols-" $NUM_SYMBOLS "") &>/dev/null || true &
-docker rm -f syntect-server &>/dev/null || true &
-docker rm -f $(addresses "zoekt-indexserver-" $NUM_INDEXED_SEARCH "") &>/dev/null || true &
-docker rm -f $(addresses "zoekt-webserver-" $NUM_INDEXED_SEARCH "") &>/dev/null || true &
-docker rm -f otel-collector &>/dev/null || true &
+docker rm -f cadvisor &> /dev/null || true &
+docker rm -f caddy    &> /dev/null || true &
+docker rm -f sourcegraph-frontend-internal &> /dev/null || true &
+docker rm -f $(addresses "sourcegraph-frontend-" $NUM_FRONTEND "") &> /dev/null || true &
+docker rm -f github-proxy &> /dev/null || true &
+docker rm -f $(addresses "gitserver-" $NUM_GITSERVER "") &> /dev/null || true &
+docker rm -f grafana &> /dev/null || true
+docker rm -f jaeger &> /dev/null || true
+docker rm -f precise-code-intel-worker &> /dev/null || true
+docker rm -f pgsql &> /dev/null || true &
+docker rm -f codeintel-db &> /dev/null || true &
+docker rm -f codeinsights-db &> /dev/null || true &
+docker rm -f minio &> /dev/null || true &
+docker rm -f migrator &> /dev/null || true &
+docker rm -f prometheus &> /dev/null || true
+docker rm -f redis-cache &> /dev/null || true &
+docker rm -f redis-store &> /dev/null || true &
+docker rm -f repo-updater &> /dev/null || true &
+docker rm -f worker &> /dev/null || true &
+docker rm -f $(addresses "searcher-" $NUM_SEARCHER "") &> /dev/null || true &
+docker rm -f $(addresses "symbols-" $NUM_SYMBOLS "") &> /dev/null || true &
+docker rm -f syntect-server &> /dev/null || true &
+docker rm -f $(addresses "zoekt-indexserver-" $NUM_INDEXED_SEARCH "") &> /dev/null || true &
+docker rm -f $(addresses "zoekt-webserver-" $NUM_INDEXED_SEARCH "") &> /dev/null || true &
+docker rm -f otel-collector &> /dev/null || true &
 
-docker network rm sourcegraph &>/dev/null || true &
+docker network rm sourcegraph &> /dev/null || true &
 wait

--- a/pure-docker/teardown.sh
+++ b/pure-docker/teardown.sh
@@ -6,31 +6,32 @@ cd "$root_dir"
 
 source ./replicas.sh
 
-docker rm -f cadvisor &> /dev/null || true &
-docker rm -f caddy    &> /dev/null || true &
-docker rm -f sourcegraph-frontend-internal &> /dev/null || true &
-docker rm -f $(addresses "sourcegraph-frontend-" $NUM_FRONTEND "") &> /dev/null || true &
-docker rm -f github-proxy &> /dev/null || true &
-docker rm -f $(addresses "gitserver-" $NUM_GITSERVER "") &> /dev/null || true &
-docker rm -f grafana &> /dev/null || true
-docker rm -f jaeger &> /dev/null || true
-docker rm -f precise-code-intel-worker &> /dev/null || true
-docker rm -f pgsql &> /dev/null || true &
-docker rm -f codeintel-db &> /dev/null || true &
-docker rm -f codeinsights-db &> /dev/null || true &
-docker rm -f minio &> /dev/null || true &
-docker rm -f migrator &> /dev/null || true &
-docker rm -f prometheus &> /dev/null || true
-docker rm -f redis-cache &> /dev/null || true &
-docker rm -f redis-store &> /dev/null || true &
-docker rm -f repo-updater &> /dev/null || true &
-docker rm -f worker &> /dev/null || true &
-docker rm -f $(addresses "searcher-" $NUM_SEARCHER "") &> /dev/null || true &
-docker rm -f $(addresses "symbols-" $NUM_SYMBOLS "") &> /dev/null || true &
-docker rm -f syntect-server &> /dev/null || true &
-docker rm -f $(addresses "zoekt-indexserver-" $NUM_INDEXED_SEARCH "") &> /dev/null || true &
-docker rm -f $(addresses "zoekt-webserver-" $NUM_INDEXED_SEARCH "") &> /dev/null || true &
-docker rm -f otel-collector &> /dev/null || true &
+docker rm -f node-exporter &>/dev/null || true &
+docker rm -f cadvisor &>/dev/null || true &
+docker rm -f caddy &>/dev/null || true &
+docker rm -f sourcegraph-frontend-internal &>/dev/null || true &
+docker rm -f $(addresses "sourcegraph-frontend-" $NUM_FRONTEND "") &>/dev/null || true &
+docker rm -f github-proxy &>/dev/null || true &
+docker rm -f $(addresses "gitserver-" $NUM_GITSERVER "") &>/dev/null || true &
+docker rm -f grafana &>/dev/null || true
+docker rm -f jaeger &>/dev/null || true
+docker rm -f precise-code-intel-worker &>/dev/null || true
+docker rm -f pgsql &>/dev/null || true &
+docker rm -f codeintel-db &>/dev/null || true &
+docker rm -f codeinsights-db &>/dev/null || true &
+docker rm -f minio &>/dev/null || true &
+docker rm -f migrator &>/dev/null || true &
+docker rm -f prometheus &>/dev/null || true
+docker rm -f redis-cache &>/dev/null || true &
+docker rm -f redis-store &>/dev/null || true &
+docker rm -f repo-updater &>/dev/null || true &
+docker rm -f worker &>/dev/null || true &
+docker rm -f $(addresses "searcher-" $NUM_SEARCHER "") &>/dev/null || true &
+docker rm -f $(addresses "symbols-" $NUM_SYMBOLS "") &>/dev/null || true &
+docker rm -f syntect-server &>/dev/null || true &
+docker rm -f $(addresses "zoekt-indexserver-" $NUM_INDEXED_SEARCH "") &>/dev/null || true &
+docker rm -f $(addresses "zoekt-webserver-" $NUM_INDEXED_SEARCH "") &>/dev/null || true &
+docker rm -f otel-collector &>/dev/null || true &
 
-docker network rm sourcegraph &> /dev/null || true &
+docker network rm sourcegraph &>/dev/null || true &
 wait

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -10,14 +10,14 @@ deploy_sourcegraph() {
 
 		if [[ "$GIT_BRANCH" == *"customer-replica"* ]]; then
 			# Expected number of containers on e.g. 3.18-customer-replica branch.
-			expect_containers="60"
+			expect_containers="61"
 		else
 			# Expected number of containers on `master` branch.
-			expect_containers="25"
+			expect_containers="26"
 		fi
 	elif [[ "$TEST_TYPE" == "docker-compose-test" ]]; then
 		docker-compose --file docker-compose/docker-compose.yaml up -d -t 600
-		expect_containers="26"
+		expect_containers="27"
 	fi
 
 	echo "Giving containers 90s to start..."


### PR DESCRIPTION
Following https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/194, this PR adds node-exporter to our docker-compose deployments. 

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: https://github.com/sourcegraph/deploy-sourcegraph/pull/4197
* [x] All images have a valid tag and SHA256 sum
### Test plan

Ran ./deploy-node-exporter.sh locally + ran local [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/master/docker-compose/dev) config (and saw node-exporter Prometheus metrics). 
