### PR TITLE
prometheus: change scrape interval to 30s

### DIFF
--- a/prometheus/docker_rules.yml
+++ b/prometheus/docker_rules.yml
@@ -1,9 +1,5 @@
 # Docker container monitoring rules
 
-global:
-  scrape_interval:     30s
-  evaluation_interval: 30s
-
 groups:
   - name: docker.rules
     rules:

--- a/prometheus/docker_rules.yml
+++ b/prometheus/docker_rules.yml
@@ -1,5 +1,9 @@
 # Docker container monitoring rules
 
+global:
+  scrape_interval:     30s
+  evaluation_interval: 30s
+
 groups:
   - name: docker.rules
     rules:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,35 @@
+# Prometheus global config
+global:
+  scrape_interval:     30s
+  evaluation_interval: 30s
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    # bundled alertmanager, started by prom-wrapper
+    - static_configs:
+        - targets: ['127.0.0.1:9093']
+      path_prefix: /alertmanager
+    # add more alertmanagers here
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  - '*_rules.yml'
+  - '/sg_prometheus_add_ons/*_rules.yml'
+
+# Configure targets to scrape
+scrape_configs:
+  # Scrape prometheus itself for metrics.
+  - job_name: 'builtin-prometheus'
+    static_configs:
+      - targets: ['127.0.0.1:9092']
+  - job_name: 'builtin-alertmanager'
+    metrics_path: /alertmanager/metrics
+    static_configs:
+      - targets: ['127.0.0.1:9093']
+
+  - job_name: 'sg'
+    file_sd_configs:
+      - files:
+          - '/sg_prometheus_add_ons/*_targets.yml'


### PR DESCRIPTION
<!-- description here -->

This change docker-compose's Prometheus scrape interval to be 30s, which brings it inline with our existing k8s configuration: 

https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/22bed12869be633318d7b56cf3ad8f04d9b4b67b/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml#L5-L7

Doing so allows us to create "higher resolution" dashboards that aggregate over 1m (~twice the sample rate, following [Nyquist–Shannon](https://www.allaboutcircuits.com/technical-articles/nyquist-shannon-theorem-understanding-sampled-systems/)).

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: N/A
* [x] All images have a valid tag and SHA256 sum
### Test plan

Ran local docker-compose dev stack,  verified that prometheus dashboards still work:

<img width="1003" alt="Screen Shot 2022-11-09 at 9 31 13 AM" src="https://user-images.githubusercontent.com/9022011/200900034-0684dd14-ec1c-44b5-99a6-3d2d5dea2f39.png">

