### PR TITLE
Move docker compose installation scripts from docsite

### DIFF
--- a/docker-compose/scripts/install-aws.sh
+++ b/docker-compose/scripts/install-aws.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+###############################################################################
+# ACTION REQUIRED: REPLACE THE URL AND REVISION WITH YOUR DEPLOYMENT REPO INFO
+###############################################################################
+# Please read the notes below the script if you are cloning a private repository
+# Example: DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION="$1"
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
+DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/home/ec2-user/deploy-sourcegraph-docker'
+DOCKER_COMPOSE_VERSION='1.29.2'
+DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'
+DOCKER_DATA_ROOT='/mnt/docker-data'
+EBS_VOLUME_DEVICE_NAME='/dev/sdb'
+EBS_VOLUME_LABEL='sourcegraph'
+# Install git
+yum update -y
+yum install git -y
+# Clone the deployment repository
+git clone "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL}" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+git checkout "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION}"
+# Format (if unformatted) and then mount the attached volume
+device_fs=$(lsblk "${EBS_VOLUME_DEVICE_NAME}" --noheadings --output fsType)
+if [ "${device_fs}" == "" ]; then
+    mkfs -t xfs "${EBS_VOLUME_DEVICE_NAME}"
+fi
+xfs_admin -L "${EBS_VOLUME_LABEL}" "${EBS_VOLUME_DEVICE_NAME}"
+mkdir -p "${DOCKER_DATA_ROOT}"
+mount -L "${EBS_VOLUME_LABEL}" "${DOCKER_DATA_ROOT}"
+# Mount file system by label on reboot
+echo "LABEL=${EBS_VOLUME_LABEL}  ${DOCKER_DATA_ROOT}  xfs  defaults,nofail  0  2" >>'/etc/fstab'
+umount "${DOCKER_DATA_ROOT}"
+mount -a
+# Install, configure, and enable Docker
+yum update -y
+amazon-linux-extras install docker
+systemctl enable --now docker
+sed -i -e 's/1024/262144/g' /etc/sysconfig/docker
+sed -i -e 's/4096/262144/g' /etc/sysconfig/docker
+usermod -a -G docker ec2-user
+# Install jq for scripting
+yum install -y jq
+## Initialize the config file with empty json if it doesn't exist
+if [ ! -f "${DOCKER_DAEMON_CONFIG_FILE}" ]; then
+    mkdir -p $(dirname "${DOCKER_DAEMON_CONFIG_FILE}")
+    echo '{}' >"${DOCKER_DAEMON_CONFIG_FILE}"
+fi
+## Point Docker storage to mounted volume
+tmp_config=$(mktemp)
+trap "rm -f ${tmp_config}" EXIT
+cat "${DOCKER_DAEMON_CONFIG_FILE}" | jq --arg DATA_ROOT "${DOCKER_DATA_ROOT}" '.["data-root"]=$DATA_ROOT' >"${tmp_config}"
+cat "${tmp_config}" >"${DOCKER_DAEMON_CONFIG_FILE}"
+# Restart Docker daemon to pick up new changes
+systemctl restart --now docker
+# Install Docker Compose
+curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+curl -L "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
+# Start Sourcegraph with Docker Compose
+cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
+docker-compose up -d --remove-orphans

--- a/docker-compose/scripts/install-aws.sh
+++ b/docker-compose/scripts/install-aws.sh
@@ -6,8 +6,11 @@ set -euxo pipefail
 # Please read the notes below the script if you are cloning a private repository
 # Example: DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
 DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION="$1"
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL="$2"
 ##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
+if [ "$2" = "" ]; then
+    DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+fi
 DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/home/ec2-user/deploy-sourcegraph-docker'
 DOCKER_COMPOSE_VERSION='1.29.2'
 DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'

--- a/docker-compose/scripts/install-azure.sh
+++ b/docker-compose/scripts/install-azure.sh
@@ -6,8 +6,11 @@ set -euxo pipefail
 # Please read the notes below the script if you are cloning a private repository
 # Example: DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
 DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION="$1"
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL="$2"
 ##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
+if [ "$2" = "" ]; then
+    DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+fi
 DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
 DOCKER_COMPOSE_VERSION='1.29.2'
 DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'

--- a/docker-compose/scripts/install-azure.sh
+++ b/docker-compose/scripts/install-azure.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+###############################################################################
+# ACTION REQUIRED: REPLACE THE URL AND REVISION WITH YOUR DEPLOYMENT REPO INFO
+###############################################################################
+# Please read the notes below the script if you are cloning a private repository
+# Example: DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION="$1"
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
+DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
+DOCKER_COMPOSE_VERSION='1.29.2'
+DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'
+DOCKER_DATA_ROOT='/mnt/docker-data'
+PERSISTENT_DISK_DEVICE_NAME='/dev/sdb'
+PERSISTENT_DISK_LABEL='sourcegraph'
+# Install git
+sudo apt-get update -y
+sudo apt-get install -y git
+# Clone the deployment repository
+git clone "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL}" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+git checkout "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION}"
+# Format (if unformatted) and then mount the attached volume
+device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)
+if [ "${device_fs}" == "" ]; then
+    sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "${PERSISTENT_DISK_DEVICE_NAME}"
+fi
+sudo e2label "${PERSISTENT_DISK_DEVICE_NAME}" "${PERSISTENT_DISK_LABEL}"
+sudo mkdir -p "${DOCKER_DATA_ROOT}"
+sudo mount -o discard,defaults "${PERSISTENT_DISK_DEVICE_NAME}" "${DOCKER_DATA_ROOT}"
+# Mount file system by label on reboot
+sudo echo "LABEL=${PERSISTENT_DISK_LABEL}  ${DOCKER_DATA_ROOT}  ext4  discard,defaults,nofail  0  2" | sudo tee -a /etc/fstab
+sudo umount "${DOCKER_DATA_ROOT}"
+sudo mount -a
+# Install, configure, and enable Docker
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-get update -y
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update -y
+apt-cache policy docker-ce
+apt-get install -y docker-ce docker-ce-cli containerd.io
+## Enable Docker at startup
+sudo systemctl enable --now docker
+## Install jq for scripting
+sudo apt-get update -y
+sudo apt-get install -y jq
+## Initialize the config file with empty json if it doesn't exist
+if [ ! -f "${DOCKER_DAEMON_CONFIG_FILE}" ]; then
+    mkdir -p $(dirname "${DOCKER_DAEMON_CONFIG_FILE}")
+    echo '{}' >"${DOCKER_DAEMON_CONFIG_FILE}"
+fi
+## Point Docker storage to mounted volume
+tmp_config=$(mktemp)
+trap "rm -f ${tmp_config}" EXIT
+sudo cat "${DOCKER_DAEMON_CONFIG_FILE}" | sudo jq --arg DATA_ROOT "${DOCKER_DATA_ROOT}" '.["data-root"]=$DATA_ROOT' >"${tmp_config}"
+sudo cat "${tmp_config}" >"${DOCKER_DAEMON_CONFIG_FILE}"
+## Restart Docker daemon to pick up new changes
+sudo systemctl restart --now docker
+# Install Docker Compose
+curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+curl -L "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
+# Start Sourcegraph with Docker Compose
+cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
+docker-compose up -d --remove-orphans

--- a/docker-compose/scripts/install-digitalocean.sh
+++ b/docker-compose/scripts/install-digitalocean.sh
@@ -6,8 +6,11 @@ set -euxo pipefail
 # Please read the notes below the script if you are cloning a private repository
 # Example: DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
 DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION="$1"
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL="$2"
 ##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
+if [ "$2" = "" ]; then
+    DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+fi
 DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
 DOCKER_DATA_ROOT='/mnt/docker-data'
 DOCKER_COMPOSE_VERSION='1.29.2'

--- a/docker-compose/scripts/install-digitalocean.sh
+++ b/docker-compose/scripts/install-digitalocean.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+###############################################################################
+# ACTION REQUIRED: REPLACE THE URL AND REVISION WITH YOUR DEPLOYMENT REPO INFO
+###############################################################################
+# Please read the notes below the script if you are cloning a private repository
+# Example: DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION="$1"
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
+DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
+DOCKER_DATA_ROOT='/mnt/docker-data'
+DOCKER_COMPOSE_VERSION='1.29.2'
+DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'
+PERSISTENT_DISK_DEVICE_NAME='/dev/sda'
+# Install git
+sudo apt-get update -y
+sudo apt-get install -y git
+# Clone the deployment repository
+git clone "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL}" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+git checkout "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION}"
+# Format (if unformatted) and then mount the attached volume
+device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)
+if [ "${device_fs}" == "" ]; then
+    sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "${PERSISTENT_DISK_DEVICE_NAME}"
+fi
+sudo mkdir -p "${DOCKER_DATA_ROOT}"
+sudo mount -o discard,defaults "${PERSISTENT_DISK_DEVICE_NAME}" "${DOCKER_DATA_ROOT}"
+# Mount file system by UUID on reboot
+DISK_UUID=$(sudo blkid -s UUID -o value "${PERSISTENT_DISK_DEVICE_NAME}")
+sudo echo "UUID=${DISK_UUID}  ${DOCKER_DATA_ROOT}  ext4  discard,defaults,nofail  0  2" >>'/etc/fstab'
+sudo umount "${DOCKER_DATA_ROOT}"
+sudo mount -a
+# Install, configure, and enable Docker
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update -y
+apt-cache policy docker-ce
+apt-get install -y docker-ce docker-ce-cli containerd.io
+## Enable Docker at startup
+sudo systemctl enable --now docker
+# Install jq for scripting
+sudo apt-get update -y
+sudo apt-get install -y jq
+## Initialize the config file with empty json if it doesn't exist
+if [ ! -f "${DOCKER_DAEMON_CONFIG_FILE}" ]; then
+    mkdir -p $(dirname "${DOCKER_DAEMON_CONFIG_FILE}")
+    echo '{}' >"${DOCKER_DAEMON_CONFIG_FILE}"
+fi
+## Point Docker storage to mounted volume
+tmp_config=$(mktemp)
+trap "rm -f ${tmp_config}" EXIT
+sudo cat "${DOCKER_DAEMON_CONFIG_FILE}" | sudo jq --arg DATA_ROOT "${DOCKER_DATA_ROOT}" '.["data-root"]=$DATA_ROOT' >"${tmp_config}"
+sudo cat "${tmp_config}" >"${DOCKER_DAEMON_CONFIG_FILE}"
+## Restart Docker daemon to pick up new changes
+sudo systemctl restart --now docker
+# Install Docker Compose
+curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+curl -L "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
+# Start Sourcegraph with Docker Compose
+cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
+docker-compose up -d --remove-orphans

--- a/docker-compose/scripts/install-gcp.sh
+++ b/docker-compose/scripts/install-gcp.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+###############################################################################
+# ACTION REQUIRED: REPLACE THE URL AND REVISION WITH YOUR DEPLOYMENT REPO INFO
+###############################################################################
+# Please read the notes below the script if you are cloning a private repository
+# Example: DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION="$1"
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
+# IMPORTANT: DO NOT MAKE ANY CHANGES FROM THIS POINT ONWARD
+DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
+DOCKER_COMPOSE_VERSION='1.29.2'
+DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'
+DOCKER_DATA_ROOT='/mnt/docker-data'
+PERSISTENT_DISK_DEVICE_NAME='/dev/sdb'
+PERSISTENT_DISK_LABEL='sourcegraph'
+# Install git
+sudo apt-get update -y
+sudo apt-get install -y git
+# Clone the deployment repository
+git clone "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL}" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
+git checkout "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION}"
+# Format (if unformatted) and then mount the attached volume
+device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)
+if [ "${device_fs}" == "" ]; then ## only format the volume if it isn't already formatted
+    sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "${PERSISTENT_DISK_DEVICE_NAME}"
+fi
+sudo e2label "${PERSISTENT_DISK_DEVICE_NAME}" "${PERSISTENT_DISK_LABEL}"
+sudo mkdir -p "${DOCKER_DATA_ROOT}"
+sudo mount -o discard,defaults "${PERSISTENT_DISK_DEVICE_NAME}" "${DOCKER_DATA_ROOT}"
+# Mount file system by label on reboot
+sudo echo "LABEL=${PERSISTENT_DISK_LABEL}  ${DOCKER_DATA_ROOT}  ext4  discard,defaults,nofail  0  2" | sudo tee -a /etc/fstab
+sudo umount "${DOCKER_DATA_ROOT}"
+sudo mount -a
+# Install, configure, and enable Docker
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-get update -y
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update -y
+apt-cache policy docker-ce
+apt-get install -y docker-ce docker-ce-cli containerd.io
+## Enable Docker at startup
+sudo systemctl enable --now docker
+## Install jq for scripting
+sudo apt-get update -y
+sudo apt-get install -y jq
+## Initialize the config file with empty json if it doesn't exist
+if [ ! -f "${DOCKER_DAEMON_CONFIG_FILE}" ]; then
+    mkdir -p $(dirname "${DOCKER_DAEMON_CONFIG_FILE}")
+    echo '{}' >"${DOCKER_DAEMON_CONFIG_FILE}"
+fi
+## Point Docker storage to mounted volume
+tmp_config=$(mktemp)
+trap "rm -f ${tmp_config}" EXIT
+sudo cat "${DOCKER_DAEMON_CONFIG_FILE}" | sudo jq --arg DATA_ROOT "${DOCKER_DATA_ROOT}" '.["data-root"]=$DATA_ROOT' >"${tmp_config}"
+sudo cat "${tmp_config}" >"${DOCKER_DAEMON_CONFIG_FILE}"
+## Restart Docker daemon to pick up new changes
+sudo systemctl restart --now docker
+# Install Docker Compose
+curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+curl -L "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
+# Start Sourcegraph with Docker Compose
+cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
+docker-compose up -d --remove-orphans

--- a/docker-compose/scripts/install-gcp.sh
+++ b/docker-compose/scripts/install-gcp.sh
@@ -6,9 +6,11 @@ set -euxo pipefail
 # Please read the notes below the script if you are cloning a private repository
 # Example: DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
 DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION="$1"
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL="$2"
 ##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
-# IMPORTANT: DO NOT MAKE ANY CHANGES FROM THIS POINT ONWARD
+if [ "$2" = "" ]; then
+    DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
+fi
 DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
 DOCKER_COMPOSE_VERSION='1.29.2'
 DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'


### PR DESCRIPTION
<!-- description here -->

Related to https://github.com/sourcegraph/sourcegraph/pull/44449

Currently, the docker-compose installation scripts for each cloud provider are stored in our doc site, and it takes up half of the page, [example](https://docs.sourcegraph.com/admin/deploy/docker-compose/aws#advanced-details-user-data):
![image](https://user-images.githubusercontent.com/68532117/202029391-edebc8b4-fdb8-43c1-b2ae-c58794a55047.png)

This PR proposed to move the scripts from doc site to the [docker compose reference repo](https://github.com/sourcegraph/deploy-sourcegraph-docker), and allow users to install via curl command instead of copying a big block of text. Example:
![image](https://user-images.githubusercontent.com/68532117/202030232-3fbf1aea-49cc-4ad8-a6e9-7c2bf9dd8489.png)

Same format is currently being used in our k3s installation guide: https://docs.sourcegraph.com/admin/deploy/single-node/k3s#start-up-script

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [N/A] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [N/A] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

These are the same scripts that are being used by our customers from our docs site.