### PR TITLE
Add relative path for rules in sg_config_prometheus

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -15,7 +15,7 @@ alerting:
 
 # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
 rule_files:
-  - '*_rules.yml'
+  - '/sg_config_prometheus/*_rules.yml'
   - '/sg_prometheus_add_ons/*_rules.yml'
 
 # Configure targets to scrape


### PR DESCRIPTION
<!-- description here -->
After upgrading to 4.2, the alerts were missing in Prometheus.

<img width="1273" alt="Screen Shot 2022-12-26 at 2 47 24 PM" src="https://user-images.githubusercontent.com/69164745/209587148-40ca9398-a80d-420e-9577-6db278534f4d.png">

This is the config in Prometheus. The root directory of [prometheus.yml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/prometheus/prometheus.yml) is now [`sg_prometheus_add_ons`](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml#L463), so there is no path to the rules in `/sg_config_prometheus/`
https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/docker-images/prometheus/prometheus.sh?L7 

<img width="481" alt="Screen Shot 2022-12-26 at 2 48 03 PM" src="https://user-images.githubusercontent.com/69164745/209587166-80e251f3-9761-47a3-9e37-9846f95096b6.png">


Adding the path to the rules in `/sg_config_prometheus` added `/sg_config_prometheus/` to the config and brought the alerts back. This is how it's configured in k8s too: 
https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/prometheus/prometheus.ConfigMap.yaml#L26

<img width="1266" alt="Screen Shot 2022-12-26 at 3 23 45 PM" src="https://user-images.githubusercontent.com/69164745/209588191-df5cda6a-d0e1-4633-9ea2-4b5bcfd165e3.png">

<img width="434" alt="Screen Shot 2022-12-26 at 3 24 05 PM" src="https://user-images.githubusercontent.com/69164745/209588196-9a64055d-02a2-487a-a3b3-8a804c78eef5.png">


### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change: Only affects Docker deployments
* [ ] All images have a valid tag and SHA256 sum
### Test plan
Checked that the alerts were present in Prometheus and Grafana.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
