### PR TITLE
Update to Go 1.19.6

### DIFF
--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.18"
+          go-version: "^1.19"
 
       # generate update
       - name: Pin tags to ${{ github.event.inputs.semver }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 nodejs 16.7.0
 yarn 1.22.4
 shellcheck 0.7.1
-golang 1.19.3
+golang 1.19.6
 python system


### PR DESCRIPTION
Update to 1.19.6 because it fixes a bunch of CVEs.

[_Created by Sourcegraph batch change `jhchabran/update-to-go-1.19.6`._](https://sourcegraph.sourcegraph.com/users/jhchabran/batch-changes/update-to-go-1.19.6)

Test Plan: CI