### PR TITLE
Update to Go 1.19.7

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 nodejs 16.7.0
 yarn 1.22.4
 shellcheck 0.7.1
-golang 1.19.6
+golang 1.19.7
 python system


### PR DESCRIPTION
Update to 1.19.7 because it fixes CVE-2023-24532

[_Created by Sourcegraph batch change `evict/update-to-go-1.19.7`._](https://sourcegraph.sourcegraph.com/users/evict/batch-changes/update-to-go-1.19.7)