### PR TITLE
Update to Go 1.19.8

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 nodejs 16.7.0
 yarn 1.22.4
 shellcheck 0.7.1
-golang 1.19.7
+golang 1.19.8
 python system


### PR DESCRIPTION
Update to 1.19.8 because it fixes multiple vulnerabilities.

[_Created by Sourcegraph batch change `evict/update-to-go1.19.8`._](https://sourcegraph.sourcegraph.com/users/evict/batch-changes/update-to-go1.19.8)

## Test plan
CI