### PR TITLE
updated scratch bind mount volume config for executor service

### DIFF
--- a/docker-compose/executors/executor.docker-compose.yaml
+++ b/docker-compose/executors/executor.docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       # Choose what work to process
       - EXECUTOR_QUEUE_NAME=
       # Note: Must match left-hand side of scratch volume mount
-      - EXECUTOR_DOCKER_HOST_MOUNT_PATH=/tmp/sourcegraph/executor-scratch
+      - EXECUTOR_DOCKER_HOST_MOUNT_PATH=/scratch
       # Note: Must match right-hand side of scratch volume mount
       - TMPDIR=/scratch
       # Run as root (required for docker daemon control)
@@ -27,7 +27,7 @@ services:
       # Mount docker socket
       - '/var/run/docker.sock:/var/run/docker.sock'
       # Mount volume for workspaces shared by executor and launched containers
-      - '/tmp/sourcegraph/executor-scratch:/scratch'
+      - '/scratch:/scratch'
     networks:
       - sourcegraph
     restart: always


### PR DESCRIPTION
Addressing a bug observed when deploying the default executor docker-compose manifest
![Screenshot 2023-05-09 at 21 34 53](https://github.com/sourcegraph/deploy-sourcegraph-docker/assets/31862633/ccae0667-e3e2-4993-ba9a-b02c8c600db9)
related slack thread: https://sourcegraph.slack.com/archives/C02MR5PPMKJ/p1683741238126119
### Checklist
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan
- tested these changes on a v5.0.3 docker-compose Sourcegraph instance
