### PR TITLE
Add Embeddings service

### DIFF
--- a/docker-compose/embeddings/embeddings.docker-compose.yaml
+++ b/docker-compose/embeddings/embeddings.docker-compose.yaml
@@ -1,0 +1,50 @@
+version: '2.4'
+services:
+  # Description: Handles embeddings searches for Cody.
+  #
+  # Ports exposed to other Sourcegraph services: 6060/TCP
+  # Ports exposed to the public internet: none
+  #
+  embeddings:
+    container_name: embeddings
+    image: 'index.docker.io/sourcegraph/embeddings:5.0.3@sha256:1d8f05ed57e361451d92eabbb3a0d90169c1108f48a274d556e43f541190e01a'
+    cpus: 4
+    mem_limit: '64g'
+    environment:
+      - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
+      - 'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317'
+      - 'SRC_GIT_SERVERS=gitserver-0:3178'
+      # Assuming you use the blobstore deployment, this is all it takes to access
+      # stored embeddings from this service. If you use a cloud storage bucket,
+      # configure by following the docs 
+      # https://docs.sourcegraph.com/cody/explanations/code_graph_context#storing-embedding-indexes
+      # IMPORTANT: config must match `worker` below
+      - 'EMBEDDINGS_UPLOAD_BACKEND=blobstore'
+      - 'EMBEDDINGS_UPLOAD_AWS_ENDPOINT=http://blobstore:9000'
+    networks:
+      - sourcegraph
+    restart: always
+
+  worker:
+    environment:
+      - 'EMBEDDINGS_UPLOAD_BACKEND=blobstore'
+      - 'EMBEDDINGS_UPLOAD_AWS_ENDPOINT=http://blobstore:9000'
+
+  sourcegraph-frontend-0:
+    environment:
+      # Adding embeddings and to the list of prof services. (Last entry is new).
+      - |
+        SRC_PROF_SERVICES=
+          [
+            { "Name": "frontend-0", "Host": "sourcegraph-frontend-0:6060" },
+            { "Name": "frontend-internal-0", "Host": "sourcegraph-frontend-internal:6060" },
+            { "Name": "gitserver-0", "Host": "gitserver-0:6060" },
+            { "Name": "searcher-0", "Host": "searcher-0:6060" },
+            { "Name": "symbols-0", "Host": "symbols-0:6060" },
+            { "Name": "repo-updater", "Host": "repo-updater:6060" },
+            { "Name": "github-proxy", "Host": "github-proxy:6060" },
+            { "Name": "worker", "Host": "worker:6060" },
+            { "Name": "zoekt-indexserver-0", "Host": "zoekt-indexserver-0:6072" },
+            { "Name": "zoekt-webserver-0", "Host": "zoekt-webserver-0:6070", "DefaultPath": "/debug/requests/" },
+            { "Name": "embeddings", "Host": "embeddings:6060" }
+          ]


### PR DESCRIPTION
Backports change adding Embeddings service from https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/918

### Test plan
See PR above
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
