### PR TITLE
Fix cgo issues causing a panic

### DIFF
--- a/pure-docker/deploy-prometheus.sh
+++ b/pure-docker/deploy-prometheus.sh
@@ -21,6 +21,5 @@ docker run --detach \
     -v $VOLUME:/prometheus \
     -v $(pwd)/../prometheus:/sg_prometheus_add_ons \
     -e SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090 \
-    index.docker.io/sourcegraph/prometheus:5.0.6@sha256:08fd31f6ba5289ac9468c2e456d4cad6076889195f4c23722273ec1d80a2f317
-
-# index.docker.io/sourcegraph/prometheus:5.1.0@sha256:6f2848c3aad6d6f8b82be138bb581e07129213624264fc0b20ab96b3c8874438
+    -e GODEBUG=netdns=go \
+    index.docker.io/sourcegraph/prometheus:5.1.0@sha256:6f2848c3aad6d6f8b82be138bb581e07129213624264fc0b20ab96b3c8874438


### PR DESCRIPTION
Follow-up to https://sourcegraph.slack.com/archives/C04MYFW01NV/p1687904137730639 where @unknwon spotted a failure in the pure-docker test suite, I was ablet to root-cause the issues down to the prom-wrapper binary being built with netgo but with cgo enabled, which led to a weird case, where it still tried to nslookup with cgo and segfaulted.

Passes the pure-docker test. See also long term fix: https://github.com/sourcegraph/sourcegraph/pull/54359

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [x] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [x] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

CI is green