### PR TITLE
Update Caddy version to 2.7.4

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
   # https://caddyserver.com/docs/caddyfile
   caddy:
     container_name: caddy
-    image: 'index.docker.io/caddy:2.7.3-alpine@sha256:f9824933254e3e43e0508670ee9bdcde704621017e95119a05317383b1878f4f'
+    image: 'index.docker.io/caddy:2.7.4-alpine@sha256:3d1bf053476f2415b40e728c37e1112ee7551fa154a63d6f62b275c13fea8166'
     cpus: 4
     mem_limit: '4g'
     environment:

--- a/pure-docker/deploy-caddy.sh
+++ b/pure-docker/deploy-caddy.sh
@@ -32,5 +32,5 @@ docker run --detach \
     -p 0.0.0.0:443:443 \
     -v $VOLUME:/caddy-storage \
     --mount type=bind,source="$(pwd)"/../caddy/builtins/http.Caddyfile,target=/etc/caddy/Caddyfile \
-    index.docker.io/caddy:2.5.2-alpine@sha256:cfa7d94aa1f0c68a167b147a8573711283df2cd6fc285d220387f20206ff4874
+    index.docker.io/caddy:2.7.3-alpine@sha256:f9824933254e3e43e0508670ee9bdcde704621017e95119a05317383b1878f4f
 

--- a/pure-docker/deploy-caddy.sh
+++ b/pure-docker/deploy-caddy.sh
@@ -32,5 +32,5 @@ docker run --detach \
     -p 0.0.0.0:443:443 \
     -v $VOLUME:/caddy-storage \
     --mount type=bind,source="$(pwd)"/../caddy/builtins/http.Caddyfile,target=/etc/caddy/Caddyfile \
-    index.docker.io/caddy:2.7.3-alpine@sha256:f9824933254e3e43e0508670ee9bdcde704621017e95119a05317383b1878f4f
+    index.docker.io/caddy:2.7.4-alpine@sha256:3d1bf053476f2415b40e728c37e1112ee7551fa154a63d6f62b275c13fea8166
 


### PR DESCRIPTION
<!-- description here -->
* Update version of Caddy used by pure-docker deployment to modern version
* Update version of Caddy used by docker-compose to latest release

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
  * Caddy [not referenced](https://sourcegraph.sourcegraph.com/search?q=context:global+r:sourcegraph/deploy-sourcegraph$+caddy&patternType=standard&sm=0&groupBy=repo) in deploy-sourcegraph
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
  * Caddy [not referenced](https://sourcegraph.sourcegraph.com/search?q=context:global+r:sourcegraph/deploy-sourcegraph-docker-customer-replica-1$+caddy&patternType=standard&sm=0&groupBy=repo) in this repo
* [x] All images have a valid tag and SHA256 sum
### Test plan

- [x] Test docker-compose locally to bring up instance
- [x] Test pure-docker `deploy.sh` script locally to bring up instance

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

