### PR TITLE
Fix for prometheus scraping of cAdvisor metrics 

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -513,8 +513,8 @@ services:
     networks:
       - sourcegraph
     restart: always
-    command:
-      - --port=8080
+    expose:
+      - 48080
 
   # Description: Publishes Prometheus metrics about the machine's hardware / operating system.
   #

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -486,7 +486,7 @@ services:
   # Description: Publishes Prometheus metrics about Docker containers.
   #
   # Disk: none
-  # Ports exposed to other Sourcegraph services: 8080/TCP
+  # Ports exposed to other Sourcegraph services: 48080/TCP
   # Ports exposed to the public internet: none
   #
   cadvisor:

--- a/prometheus/prometheus_targets.yml
+++ b/prometheus/prometheus_targets.yml
@@ -3,7 +3,7 @@
     nodename: "sourcegraph-docker-compose-host"
     job: node
   targets:
-    - cadvisor:8080
+    - cadvisor:48080
     - sourcegraph-frontend-internal:6060
 - labels:
     nodename: "sourcegraph-docker-compose-host"


### PR DESCRIPTION
cAdvisor is currently not exposing its metrics endpoint over the docker container network in our default `deploy-sourcegraph-docker` docker-compose configuration, resulting in broken container level monitoring & alerting for this deployment method. This PR accomplishes the following:
- Removes unused `--port=8080` parameter passed to [cadvisor entrypoint script](https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/cadvisor/entrypoint.sh)
- Exposes the cAdvisor metrics endpoint on the docker container network on port 48080
- Updates the Prometheus target port for cAdvisor to 48080

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
Note: this brings `deploy-sourcegraph-docker` in line with [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/templates/cadvisor/cadvisor.DaemonSet.yaml#L25) and [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/base/monitoring/cadvisor/cadvisor.DaemonSet.yaml#L20) which already scrape cAdvisor on port 48080

### Test plan

Verified changes in test docker-compose deployment:
<img width="1978" alt="Screenshot 2023-11-19 at 17 48 14" src="https://github.com/sourcegraph/deploy-sourcegraph-docker/assets/31862633/1c468012-7fce-489f-b313-fa9226504592">
<img width="1978" alt="Screenshot 2023-11-19 at 17 38 19" src="https://github.com/sourcegraph/deploy-sourcegraph-docker/assets/31862633/262dd52a-cd03-4936-b980-5ba3aa92067c">

