### PR TITLE
rfc795: add release manifest

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
-
+# this script is executed by multiple buildkite agents running on one node, so we write the pid to a file
+# if the pidfile exists we know another process is executing so we don't need to install anything
+#
+# A more robust approach would be to use a lock file, but that would require some more work
 set -eu
 pushd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
 WORKDIR=$(pwd)
+PIDFILE=/var/lock/dobackup.pid
+
+remove_pidfile()
+{
+  rm -f "$PIDFILE"
+}
+
+another_instance()
+{
+  echo "There is another instance running, skipping"
+  exit 0
+}
+
+if [ -f "$PIDFILE" ]; then
+  kill -0 "$(cat $PIDFILE)" && another_instance
+fi
+trap remove_pidfile EXIT
+echo $$ > "$PIDFILE"
+
 
 echo "Installing asdf dependencies as defined in '${WORKDIR}/.tool-versions':"
 asdf install

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -35,3 +35,31 @@ steps:
     label: ":lock: security - checkov"
     agents: { queue: "standard" }
     soft_fail: true
+
+  - label: "Release: test"
+    if: "build.branch =~ /^wip_/"
+    command: |
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      ./sg-rfc795 release run test --workdir=. --config-from-commit
+
+  - wait
+
+  - label: "Release: finalize"
+    if: "build.branch =~ /^wip_/"
+    command: |
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
+  - label: "Promote to public: finalize"
+    if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
+    command: |
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -56,7 +56,7 @@ steps:
 
       ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
   - label: "Promote to public: finalize"
-    if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
+    if: build.message =~ /^promote_release/ && build.branch =~ /^wip_release/
     command: |
       wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,4 +3,3 @@ yarn 1.22.4
 shellcheck 0.7.1
 golang 1.19.8
 python system
-ruby 3.1.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,3 +3,4 @@ yarn 1.22.4
 shellcheck 0.7.1
 golang 1.19.8
 python system
+ruby 3.1.1

--- a/release.yaml
+++ b/release.yaml
@@ -35,7 +35,7 @@ internal:
               git push origin ${branch}
           - name: "gh"
             cmd: |
-              gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}"
+              gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
       minor:
           - name: docker(compose):tags
             cmd: |
@@ -55,7 +55,7 @@ internal:
               git push origin ${branch}
           - name: "gh"
             cmd: |
-              gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}"
+              gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
       major:
           - name: docker(compose):tags
             cmd: |
@@ -75,7 +75,7 @@ internal:
               git push origin ${branch}
           - name: "gh"
             cmd: |
-              gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}"
+              gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
       - name: "git:finalize"
@@ -117,7 +117,7 @@ promoteToPublic:
           branch="wip-release-{{version}}"
           # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
           git fetch origin "${branch}"
-          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${branch}"
+          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${branch}" --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
       - name: git:tag

--- a/release.yaml
+++ b/release.yaml
@@ -81,7 +81,7 @@ internal:
       - name: "git:finalize"
         cmd: |
           set -e
-          branch="wip-release-{{version}}"
+          branch="wip_release-{{version}}"
           git switch -c "${branch}"
           echo "pushing branch ${branch}"
           git push origin "${branch}"
@@ -114,7 +114,7 @@ promoteToPublic:
       - name: "gh"
         cmd: |
           set -e
-          branch="wip-release-{{version}}"
+          branch="wip_release-{{version}}"
           # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
           git fetch origin "${branch}"
           gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${branch}" --body "Test plan: automated release PR, CI will perform additional checks"
@@ -123,7 +123,7 @@ promoteToPublic:
       - name: git:tag
         cmd: |
           set -e
-          branch="wip-release-{{version}}"
+          branch="wip_release-{{version}}"
           git checkout "${branch}"
-          git tag wip-{{version}}
+          git tag wip_{{version}}
           git push origin ${branch} --tags

--- a/release.yaml
+++ b/release.yaml
@@ -16,35 +16,56 @@ requirements:
 internal:
   create:
     steps:
-      minor:
+      patch:
           - name: docker:tags
             cmd: |
+              # TODO: use {{tag}}
               ./tools/update-docker-tags.sh {{tag}}
           - name: "git:branch"
             cmd: |
-              branch="wb/wip_{{version}}"
+              branch="wip_{{version}}"
               git switch -c "${branch}"
-              git commit -am 'release-major: {{version}}' -m '{{config}}'
+              git commit -am 'release_patch: {{version}}' -m '{{config}}'
+              git push origin ${branch}
+          - name: "gh"
+            cmd: |
+              gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}"
+      minor:
+          - name: docker:tags
+            cmd: |
+              # TODO: use {{tag}}
+              ./tools/update-docker-tags.sh {{tag}}
+          - name: "git:branch"
+            cmd: |
+              branch="wip_{{version}}"
+              git switch -c "${branch}"
+              git commit -am 'release_minor: {{version}}' -m '{{config}}'
+              git push origin ${branch}
+          - name: "gh"
+            cmd: |
+              gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}"
       major:
           - name: docker:tags
             cmd: |
               ./tools/update-docker-tags.sh {{tag}}
           - name: "git:branch"
             cmd: |
-              branch="wb/wip_{{version}}"
+              branch="wip_{{version}}"
               git switch -c "${branch}"
-              git commit -am 'release-major: {{version}}' -m '{{config}}'
+              git commit -am 'release_major: {{version}}' -m '{{config}}'
+              git push origin ${branch}
+          - name: "gh"
+            cmd: |
+              gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}"
   finalize:
     steps:
       - name: "git:finalize"
         cmd: |
-          git checkout wb/wip_{{version}}
-          git push origin wb/wip_{{version}}
-
-          gh pr create -f -t "PRETEND RELEASE - release-major: build {{version}}"
-
-          git switch -c "wb/release-{{version}}"
-          git push origin wb/release-{{version}}
+          set -e
+          branch="wip-release-{{version}}"
+          git switch -c "${branch}"
+          echo "pushing branch ${branch}"
+          git push origin "${branch}"
           git checkout -
 test:
   steps:
@@ -60,11 +81,23 @@ promoteToPublic:
           ./tools/update-docker-tags.sh {{tag}}
       - name: "git:branch"
         cmd: |
-          branch="wb/promote_wip_{{version}}"
+          branch="promote-release_{{version}}"
           git switch -c "${branch}"
           git commit -am 'promote-release: {{version}}' -m '{{config}}'
-      - name: "git:push"
-        cmd: git push origin wb/promote_wip_{{version}}
-      - name: "GitHub:create PR"
+          git push origin "${branch}"
+      - name: "gh"
         cmd: |
-          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}"
+          set -e
+          branch="wip-release-{{version}}"
+          # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
+          git fetch origin "${branch}"
+          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${branch}"
+  finalize:
+    steps:
+      - name: git:tag
+        cmd: |
+          set -e
+          branch="wip-release-{{version}}"
+          git checkout "${branch}"
+          git tag wip-{{version}}
+          git push origin ${branch} --tags

--- a/release.yaml
+++ b/release.yaml
@@ -1,0 +1,70 @@
+---
+meta:
+  productName: "deploy-sourcegraph-docker"
+  owners:
+    - "@sourcegraph/release"
+  repository: "github.com/sourcegraph/deploy-sourcegraph-docker"
+inputs:
+  releaseId: server
+requirements:
+  - name: "go"
+    cmd: "which go"
+    fixInstructions: "install golang"
+  - name: "GitHub cli exists"
+    cmd: "which gh"
+    fixInstructions: "install GitHub cli"
+internal:
+  create:
+    steps:
+      minor:
+          - name: docker:tags
+            cmd: |
+              ./tools/update-docker-tags.sh {{tag}}
+          - name: "git:branch"
+            cmd: |
+              branch="wb/wip_{{version}}"
+              git switch -c "${branch}"
+              git commit -am 'release-major: {{version}}' -m '{{config}}'
+      major:
+          - name: docker:tags
+            cmd: |
+              ./tools/update-docker-tags.sh {{tag}}
+          - name: "git:branch"
+            cmd: |
+              branch="wb/wip_{{version}}"
+              git switch -c "${branch}"
+              git commit -am 'release-major: {{version}}' -m '{{config}}'
+  finalize:
+    steps:
+      - name: "git:finalize"
+        cmd: |
+          git checkout wb/wip_{{version}}
+          git push origin wb/wip_{{version}}
+
+          gh pr create -f -t "PRETEND RELEASE - release-major: build {{version}}"
+
+          git switch -c "wb/release-{{version}}"
+          git push origin wb/release-{{version}}
+          git checkout -
+test:
+  steps:
+    - name: "foo"
+      cmd: |
+        echo "Test"
+
+promoteToPublic:
+  create:
+    steps:
+      - name: docker:tags
+        cmd: |
+          ./tools/update-docker-tags.sh {{tag}}
+      - name: "git:branch"
+        cmd: |
+          branch="wb/promote_wip_{{version}}"
+          git switch -c "${branch}"
+          git commit -am 'promote-release: {{version}}' -m '{{config}}'
+      - name: "git:push"
+        cmd: git push origin wb/promote_wip_{{version}}
+      - name: "GitHub:create PR"
+        cmd: |
+          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}"

--- a/release.yaml
+++ b/release.yaml
@@ -17,10 +17,16 @@ internal:
   create:
     steps:
       patch:
-          - name: docker:tags
+          - name: docker(compose):tags
             cmd: |
-              # TODO: use {{tag}}
-              ./tools/update-docker-tags.sh {{tag}}
+              set -e
+              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              sg-rfc ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+          - name: docker(shell):tags
+            cmd: |
+              set -e
+              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              sg-rfc ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
               branch="wip_{{version}}"
@@ -31,10 +37,16 @@ internal:
             cmd: |
               gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}"
       minor:
-          - name: docker:tags
+          - name: docker(compose):tags
             cmd: |
-              # TODO: use {{tag}}
-              ./tools/update-docker-tags.sh {{tag}}
+              set -e
+              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              sg-rfc ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+          - name: docker(shell):tags
+            cmd: |
+              set -e
+              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              sg-rfc ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
               branch="wip_{{version}}"
@@ -45,9 +57,16 @@ internal:
             cmd: |
               gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}"
       major:
-          - name: docker:tags
+          - name: docker(compose):tags
             cmd: |
-              ./tools/update-docker-tags.sh {{tag}}
+              set -e
+              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              sg-rfc ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+          - name: docker(shell):tags
+            cmd: |
+              set -e
+              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              sg-rfc ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
               branch="wip_{{version}}"
@@ -76,9 +95,16 @@ test:
 promoteToPublic:
   create:
     steps:
-      - name: docker:tags
+      - name: docker(compose):tags
         cmd: |
-          ./tools/update-docker-tags.sh {{tag}}
+          set -e
+          registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public
+          sg-rfc ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+      - name: docker(shell):tags
+        cmd: |
+          set -e
+          registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public
+          sg-rfc ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
       - name: "git:branch"
         cmd: |
           branch="promote-release_{{version}}"


### PR DESCRIPTION
Adds a release manifest for use with rfc-795 release tooling

Closes https://github.com/sourcegraph/sourcegraph/issues/59062

## TODO

- [ ] remove wip prefixes
- [ ] use normal sg instead of custom rfc build

## Test plan
Executed locally
