### PR TITLE
use service accounts in provider and add 'storage-ro' scope

### DIFF
--- a/.buildkite/vagrant-run.sh
+++ b/.buildkite/vagrant-run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
-set -euxo pipefail
+set -euo pipefail
 
 box="$1"
 exit_code=0
@@ -12,6 +12,7 @@ cleanup() {
 	vagrant destroy -f "$box"
 }
 
+echo --- ":vagrant: installing plugins"
 plugins=(vagrant-google vagrant-env vagrant-scp)
 for i in "${plugins[@]}"; do
 	if ! vagrant plugin list --no-tty | grep "$i"; then
@@ -20,6 +21,7 @@ for i in "${plugins[@]}"; do
 done
 
 trap cleanup EXIT
+echo --- ":vagrant: starting box $box"
 vagrant up "$box" --provider=google || exit_code=$?
 
 if [ "$exit_code" != 0 ]; then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -44,8 +44,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         g.network = server['network']
         g.external_ip = external_ip
         g.use_private_ip = use_private_ip
+        g.service_account = server['service_account']
         g.scopes = [
-            "compute-rw"
+            "compute-rw",
+            "storage-ro"
         ]
         o.ssh.username = username
         o.ssh.private_key_path = ssh_key_path

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -45,6 +45,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         g.external_ip = external_ip
         g.use_private_ip = use_private_ip
         g.service_account = server['service_account']
+        g.labels = {
+          "team" => "dev-infra",
+          "type" => "vagrant"
+        }
         g.scopes = [
             "compute-rw",
             "storage-ro"

--- a/test/servers.yaml
+++ b/test/servers.yaml
@@ -8,6 +8,7 @@
   network: default
   username: buildkite
   ssh_key_path: "~/.ssh/id_rsa"
+  service_account: e2e-builder@sourcegraph-ci.iam.gserviceaccount.com
   shell_commands:
    - "/deploy-sourcegraph-docker/test/smoke-test.sh"
 

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euxfo pipefail
 
+configure_docker() {
+  gcloud auth configure-docker
+  gcloud auth configure-docker us-central1-docker.pkg.dev
+}
+
 deploy_sourcegraph() {
 	cd $(dirname "${BASH_SOURCE[0]}")/..
 	#Deploy sourcegraph
@@ -64,6 +69,7 @@ catch_errors() {
 
 trap catch_errors EXIT
 
+configure_docker
 deploy_sourcegraph
 test_count
 test_containers


### PR DESCRIPTION
This allows the vagrant machines that get launched with `docker-test` to be able to pull from private registries
### Test plan
Tested here https://buildkite.com/sourcegraph/deploy-sourcegraph-docker/builds/14878#018d5b9a-659e-4e9c-90e7-8cad4faef64f
