### PR TITLE
Update caddy to 2.7.6 to patch several vulns

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
   # https://caddyserver.com/docs/caddyfile
   caddy:
     container_name: caddy
-    image: 'index.docker.io/caddy:2.7.4-alpine@sha256:3d1bf053476f2415b40e728c37e1112ee7551fa154a63d6f62b275c13fea8166'
+    image: 'index.docker.io/caddy:2.7.6-alpine@sha256:80ca561981768b2c3568cc4bef3d4cd1f11c2a625c806bedeb8453aef98779a0'
     cpus: 4
     mem_limit: '4g'
     environment:

--- a/pure-docker/deploy-caddy.sh
+++ b/pure-docker/deploy-caddy.sh
@@ -1,36 +1,35 @@
 #!/usr/bin/env bash
 set -e
 
-  # Description: Acts as a reverse proxy for all of the sourcegraph-frontend instances
-  #
-  # Disk: 1GB / persistent SSD
-  # Ports exposed to other Sourcegraph services: none
-  # Ports exposed to the public internet: 80 (HTTP) and 443 (HTTPS)
-  #
-  # Sourcegraph ships with a few builtin templates that cover common HTTP/HTTPS configurations:
-  # - HTTP only (default)
-  # - HTTPS with Let's Encrypt
-  # - HTTPS with custom certificates
-  #
-  # Follow the directions in the comments below to swap between these configurations.
-  #
-  # If none of these built-in configurations suit your needs, then you can create your own Caddyfile, see:
-  # https://caddyserver.com/docs/caddyfile
+# Description: Acts as a reverse proxy for all of the sourcegraph-frontend instances
+#
+# Disk: 1GB / persistent SSD
+# Ports exposed to other Sourcegraph services: none
+# Ports exposed to the public internet: 80 (HTTP) and 443 (HTTPS)
+#
+# Sourcegraph ships with a few builtin templates that cover common HTTP/HTTPS configurations:
+# - HTTP only (default)
+# - HTTPS with Let's Encrypt
+# - HTTPS with custom certificates
+#
+# Follow the directions in the comments below to swap between these configurations.
+#
+# If none of these built-in configurations suit your needs, then you can create your own Caddyfile, see:
+# https://caddyserver.com/docs/caddyfile
 
 VOLUME="$HOME/sourcegraph-docker/caddy-storage"
 ./ensure-volume.sh $VOLUME 100
 docker run --detach \
-    --name=caddy \
-    --network=sourcegraph \
-    --restart=always \
-    --cpus="4" \
-    --memory=4g \
-    -e XDG_DATA_HOME="/caddy-storage/data" \
-    -e XDG_CONFIG_HOME="/caddy-storage/config" \
-    -e SRC_FRONTEND_ADDRESSES="sourcegraph-frontend-0:3080" \
-    -p 0.0.0.0:80:80 \
-    -p 0.0.0.0:443:443 \
-    -v $VOLUME:/caddy-storage \
-    --mount type=bind,source="$(pwd)"/../caddy/builtins/http.Caddyfile,target=/etc/caddy/Caddyfile \
-    index.docker.io/caddy:2.7.4-alpine@sha256:3d1bf053476f2415b40e728c37e1112ee7551fa154a63d6f62b275c13fea8166
-
+  --name=caddy \
+  --network=sourcegraph \
+  --restart=always \
+  --cpus="4" \
+  --memory=4g \
+  -e XDG_DATA_HOME="/caddy-storage/data" \
+  -e XDG_CONFIG_HOME="/caddy-storage/config" \
+  -e SRC_FRONTEND_ADDRESSES="sourcegraph-frontend-0:3080" \
+  -p 0.0.0.0:80:80 \
+  -p 0.0.0.0:443:443 \
+  -v $VOLUME:/caddy-storage \
+  --mount type=bind,source="$(pwd)"/../caddy/builtins/http.Caddyfile,target=/etc/caddy/Caddyfile \
+  index.docker.io/caddy:2.7.6-alpine@sha256:80ca561981768b2c3568cc4bef3d4cd1f11c2a625c806bedeb8453aef98779a0

--- a/pure-docker/deploy-caddy.sh
+++ b/pure-docker/deploy-caddy.sh
@@ -30,6 +30,6 @@ docker run --detach \
   -e SRC_FRONTEND_ADDRESSES="sourcegraph-frontend-0:3080" \
   -p 0.0.0.0:80:80 \
   -p 0.0.0.0:443:443 \
-  -v $VOLUME:/caddy-storage \
+  -v "$VOLUME:/caddy-storage" \
   --mount type=bind,source="$(pwd)"/../caddy/builtins/http.Caddyfile,target=/etc/caddy/Caddyfile \
   index.docker.io/caddy:2.7.6-alpine@sha256:80ca561981768b2c3568cc4bef3d4cd1f11c2a625c806bedeb8453aef98779a0


### PR DESCRIPTION
Patches:
* CVE-2023-5363
* CVE-2023-45142
* CVE-2023-39325
* GHSA-m425-mq94-257g

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] ~Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:~ caddy not used
* [ ] ~Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):~ caddy not used
* [x] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

- Tested locally with `./docker-compose/dev/run.sh up`
- Checked release notes for major changes