### PR TITLE
chg/rel: use default sg

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -38,28 +38,23 @@ steps:
 
   - label: "Release: test"
     if: "build.branch =~ /^wip_/"
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
-      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
-      tar zxf sg-rfc795.tar.gz
-      chmod +x ./sg-rfc795
-
-      ./sg-rfc795 release run test --workdir=. --config-from-commit
+      sg release run test --workdir=. --config-from-commit
 
   - wait
 
   - label: "Release: finalize"
     if: "build.branch =~ /^wip_/"
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
-      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
-      tar zxf sg-rfc795.tar.gz
-      chmod +x ./sg-rfc795
+      sg release run internal finalize --workdir=. --config-from-commit
 
-      ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
   - label: "Promote to public: finalize"
     if: build.message =~ /^promote_release/ && build.branch =~ /^wip_release/
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
-      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
-      tar zxf sg-rfc795.tar.gz
-      chmod +x ./sg-rfc795
-
-      ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit
+      sg release run promote-to-public finalize --workdir=. --config-from-commit

--- a/release.yaml
+++ b/release.yaml
@@ -21,12 +21,12 @@ internal:
             cmd: |
               set -e
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg-rfc ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+              sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
           - name: docker(shell):tags
             cmd: |
               set -e
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg-rfc ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
+              sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
               branch="wip_{{version}}"
@@ -41,12 +41,12 @@ internal:
             cmd: |
               set -e
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg-rfc ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+              sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
           - name: docker(shell):tags
             cmd: |
               set -e
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg-rfc ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
+              sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
               branch="wip_{{version}}"
@@ -61,12 +61,12 @@ internal:
             cmd: |
               set -e
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg-rfc ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+              sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
           - name: docker(shell):tags
             cmd: |
               set -e
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg-rfc ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
+              sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
               branch="wip_{{version}}"
@@ -99,12 +99,12 @@ promoteToPublic:
         cmd: |
           set -e
           registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public
-          sg-rfc ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+          sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
       - name: docker(shell):tags
         cmd: |
           set -e
           registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public
-          sg-rfc ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
+          sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
       - name: "git:branch"
         cmd: |
           branch="promote-release_{{version}}"


### PR DESCRIPTION
Plugin was tested over https://github.com/sourcegraph/deploy-sourcegraph-k8s/pull/102

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan

CI 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
