### PR TITLE
Update release manifest + QA 

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -27,5 +27,8 @@ trap remove_pidfile EXIT
 echo $$ > "$PIDFILE"
 
 
+# TODO should be done in the stateless agents
+asdf plugin-add github-cli https://github.com/bartlomiejdanek/asdf-github-cli.git
+
 echo "Installing asdf dependencies as defined in '${WORKDIR}/.tool-versions':"
 asdf install

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -26,9 +26,5 @@ fi
 trap remove_pidfile EXIT
 echo $$ > "$PIDFILE"
 
-
-# TODO should be done in the stateless agents
-asdf plugin-add github-cli https://github.com/bartlomiejdanek/asdf-github-cli.git
-
 echo "Installing asdf dependencies as defined in '${WORKDIR}/.tool-versions':"
 asdf install

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -36,8 +36,18 @@ steps:
     agents: { queue: "standard" }
     soft_fail: true
 
-  - label: "Release: test"
+  # Please keep in mind that the release manifest uses specific branch names when creating releases.
+  # Therefore, if you update them, or if you decide to change how we detect what kind of build we're dealing
+  # with, please update this file as well.
+  - label: "(internal) Release: test"
     if: build.branch =~ /^internal\/release-.*/
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
+    command: |
+      sg release run test --workdir=. --config-from-commit
+
+  - label: "(promote) Release: test"
+    if: build.branch =~ /^promote\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
@@ -45,24 +55,18 @@ steps:
 
   - wait
 
-  - label: "Release: test"
-    if: build.branch =~ /^promote\/release-.*/
-    plugins:
-      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
-    command: |
-      sg release run test --workdir=. --config-from-commit
-
-
-  - label: "Release: finalize"
-    if: build.branch =~ /^promote\/release-.*/
+  - label: "(internal) Release: finalize"
+    if: build.branch =~ /^internal\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
       sg release run internal finalize --workdir=. --config-from-commit
 
-  - label: "Promote to public: finalize"
+
+  - label: "(promote) Release: finalize"
     if: build.branch =~ /^promote\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
       sg release run promote-to-public finalize --workdir=. --config-from-commit
+

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -29,13 +29,13 @@ steps:
   #   env:
   #     TEST_TYPE: "docker-compose-test"
   #   agents: { queue: "vagrant" }
-
-  # This runs the Checkov Terraform Code scanner
+  #
+  # # This runs the Checkov Terraform Code scanner
   # https://www.checkov.io/
-  - command: .buildkite/ci-checkov.sh
-    label: ":lock: security - checkov"
-    agents: { queue: "standard" }
-    soft_fail: true
+  # - command: .buildkite/ci-checkov.sh
+  #   label: ":lock: security - checkov"
+  #   agents: { queue: "standard" }
+  #   soft_fail: true
 
   # Please keep in mind that the release manifest uses specific branch names when creating releases.
   # Therefore, if you update them, or if you decide to change how we detect what kind of build we're dealing

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -37,7 +37,7 @@ steps:
     soft_fail: true
 
   - label: "Release: test"
-    if: "build.branch =~ /^wip_/"
+    if: "build.branch =~ /^internal\/release-.*/"
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
@@ -45,15 +45,23 @@ steps:
 
   - wait
 
+  - label: "Release: test"
+    if: "build.branch =~ /^promote\/release-.*/"
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
+    command: |
+      sg release run test --workdir=. --config-from-commit
+
+
   - label: "Release: finalize"
-    if: "build.branch =~ /^wip_/"
+    if: "build.branch =~ /^promote\/release-.*/"
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
       sg release run internal finalize --workdir=. --config-from-commit
 
   - label: "Promote to public: finalize"
-    if: build.message =~ /^promote_release/ && build.branch =~ /^wip_release/
+    if: "build.branch =~ /^promote\/release-.*/"
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -37,7 +37,7 @@ steps:
     soft_fail: true
 
   - label: "Release: test"
-    if: "build.branch =~ /^internal\/release-.*/"
+    if: build.branch =~ /^internal\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
@@ -46,7 +46,7 @@ steps:
   - wait
 
   - label: "Release: test"
-    if: "build.branch =~ /^promote\/release-.*/"
+    if: build.branch =~ /^promote\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
@@ -54,7 +54,7 @@ steps:
 
 
   - label: "Release: finalize"
-    if: "build.branch =~ /^promote\/release-.*/"
+    if: build.branch =~ /^promote\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -15,27 +15,26 @@ steps:
     command: .buildkite/verify-release/verify-release.sh
     agents: { queue: standard }
 
-  # Commented for faster QA
-  # - label: ":rice: pure-docker-test"
-  #   command: .buildkite/vagrant-run.sh docker-test
-  #   artifact_paths: ./*.log
-  #   env:
-  #     TEST_TYPE: "pure-docker-test"
-  #   agents: { queue: "vagrant" }
-  #
-  # - label: ":rice: docker-compose-test"
-  #   command: .buildkite/vagrant-run.sh docker-test
-  #   artifact_paths: ./*.log
-  #   env:
-  #     TEST_TYPE: "docker-compose-test"
-  #   agents: { queue: "vagrant" }
-  #
-  # # This runs the Checkov Terraform Code scanner
+  - label: ":rice: pure-docker-test"
+    command: .buildkite/vagrant-run.sh docker-test
+    artifact_paths: ./*.log
+    env:
+      TEST_TYPE: "pure-docker-test"
+    agents: { queue: "vagrant" }
+
+  - label: ":rice: docker-compose-test"
+    command: .buildkite/vagrant-run.sh docker-test
+    artifact_paths: ./*.log
+    env:
+      TEST_TYPE: "docker-compose-test"
+    agents: { queue: "vagrant" }
+
+  # This runs the Checkov Terraform Code scanner
   # https://www.checkov.io/
-  # - command: .buildkite/ci-checkov.sh
-  #   label: ":lock: security - checkov"
-  #   agents: { queue: "standard" }
-  #   soft_fail: true
+  - command: .buildkite/ci-checkov.sh
+    label: ":lock: security - checkov"
+    agents: { queue: "standard" }
+    soft_fail: true
 
   # Please keep in mind that the release manifest uses specific branch names when creating releases.
   # Therefore, if you update them, or if you decide to change how we detect what kind of build we're dealing

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -61,7 +61,7 @@ steps:
       sg release run internal finalize --workdir=. --config-from-commit
 
   - label: "Promote to public: finalize"
-    if: "build.branch =~ /^promote\/release-.*/"
+    if: build.branch =~ /^promote\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -15,19 +15,20 @@ steps:
     command: .buildkite/verify-release/verify-release.sh
     agents: { queue: standard }
 
-  - label: ":rice: pure-docker-test"
-    command: .buildkite/vagrant-run.sh docker-test
-    artifact_paths: ./*.log
-    env:
-      TEST_TYPE: "pure-docker-test"
-    agents: { queue: "vagrant" }
-
-  - label: ":rice: docker-compose-test"
-    command: .buildkite/vagrant-run.sh docker-test
-    artifact_paths: ./*.log
-    env:
-      TEST_TYPE: "docker-compose-test"
-    agents: { queue: "vagrant" }
+  # Commented for faster QA
+  # - label: ":rice: pure-docker-test"
+  #   command: .buildkite/vagrant-run.sh docker-test
+  #   artifact_paths: ./*.log
+  #   env:
+  #     TEST_TYPE: "pure-docker-test"
+  #   agents: { queue: "vagrant" }
+  #
+  # - label: ":rice: docker-compose-test"
+  #   command: .buildkite/vagrant-run.sh docker-test
+  #   artifact_paths: ./*.log
+  #   env:
+  #     TEST_TYPE: "docker-compose-test"
+  #   agents: { queue: "vagrant" }
 
   # This runs the Checkov Terraform Code scanner
   # https://www.checkov.io/

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,4 +2,5 @@ nodejs 16.7.0
 yarn 1.22.4
 shellcheck 0.7.1
 golang 1.19.8
+github-cli 2.46.0
 python system

--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ We've made our deployment configurations open source to better serve our custome
 What if your organization wants a multi-machine deployment without using Kubernetes?
 What if you use a different container management platform, for example?
 Anyone using a container management platform other than Kubernetes (Netflix's [Titus](https://netflix.github.io/titus/), Apache's [Mesos](http://mesos.apache.org/documentation/latest/docker-containerizer/), etc.) can use our [Pure-Docker Sourcegraph cluster deployment reference](./pure-docker/README.md) to deploy Sourcegraph.
+
+---
+
+### Contributing 
+
+#### Releasing 
+
+Please see the [documentation](https://go/releases).

--- a/release.yaml
+++ b/release.yaml
@@ -174,27 +174,27 @@ promoteToPublic:
           # Create the final branch holding the tagged commit
           git checkout "${promote_branch}"
           git switch -c "${release_branch}"
-          # TODO remove after QA
-          git tag QA-{{version}}
+
+          git tag {{version}}
           git push origin ${release_branch} --tags
 
           # Web URL to the tag
-          tag_url="https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/QA-{{version}}"
+          tag_url="https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/{{version}}"
 
           # Annotate PRs 
           cat << EOF | gh pr comment "$internal_branch" --body-file -
           - :green_circle: Release has been promoted, see tag: $tag_url.
-          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (\`$release_branch\`).
+          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (i.e. \`$release_branch\`).
           - :arrow_right: You can safely close that PR and delete its a associated branch.
           EOF
 
           cat << EOF | gh pr comment "$promote_branch" --body-file -
           - :green_circle: Release has been promoted, see tag: $tag_url.
-          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (\`$release_branch\`).
+          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (i.e. \`$release_branch\`).
           - :arrow_right: You can safely close that PR and delete its a associated branch.
           EOF
 
           # Annotate build
           cat << EOF | buildkite-agent annotate --style info
-          Promoted release is **publicly available** through a git tag at [\`QA-{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/QA-{{version}}).
+          Promoted release is **publicly available** through a git tag at [\`{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/{{version}}).
           EOF

--- a/release.yaml
+++ b/release.yaml
@@ -120,7 +120,7 @@ promoteToPublic:
       - name: "git"
         cmd: |
           set -e
-          branch="ready/release-{{version}}"
+          branch="internal/release-{{version}}"
           git fetch origin "${branch}"
           git switch "${branch}"
       - name: docker(compose):tags
@@ -142,14 +142,13 @@ promoteToPublic:
       - name: "github:pr"
         cmd: |
           set -e
-          branch="ready/release-{{version}}"
+          base_branch="ready/release-{{version}}"
           # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
           git fetch origin "${branch}"
-          git switch "${branch}"
           gh pr create \
             --fill \
             --title "(promote) release: build {{version}}" \
-            --base "${branch}" \
+            --base "${base_branch}" \
             --body "Test plan: automated release PR, CI will perform additional checks"
           echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:

--- a/release.yaml
+++ b/release.yaml
@@ -111,7 +111,7 @@ internal:
 
           # Post a comment on the PR.
           cat << EOF | gh pr comment "$branch" --body-file -
-          - :green_circle: Interal release is ready for promotion!
+          - :green_circle: Internal release is ready for promotion!
           - :warning: Do not close/merge that pull request or delete the associated branch if you intend to promote it.
           EOF
 

--- a/release.yaml
+++ b/release.yaml
@@ -183,7 +183,7 @@ promoteToPublic:
           git push origin ${release_branch} --tags
 
           # Web URL to the tag
-          tag_url="https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$version"
+          tag_url="https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/QA-{{version}}"
 
           # Annotate PRs 
           cat << EOF | gh pr comment "$internal_branch" --body-file -
@@ -200,5 +200,5 @@ promoteToPublic:
 
           # Annotate build
           cat << EOF | buildkite-agent annotate --style info
-          Promoted release is **publicly available** through a git tag at [\`QA-$version\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$version).
+          Promoted release is **publicly available** through a git tag at [\`QA-{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/QA-{{version}}).
           EOF

--- a/release.yaml
+++ b/release.yaml
@@ -184,13 +184,13 @@ promoteToPublic:
           # Annotate PRs 
           cat << EOF | gh pr comment "$internal_branch" --body-file -
           - :green_circle: Release has been promoted, see tag: $tag_url.
-          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (\`$release_branch\`)."
+          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (\`$release_branch\`).
           - :arrow_right: You can safely close that PR and delete its a associated branch.
           EOF
 
           cat << EOF | gh pr comment "$promote_branch" --body-file -
           - :green_circle: Release has been promoted, see tag: $tag_url.
-          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (\`$release_branch\`)."
+          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (\`$release_branch\`).
           - :arrow_right: You can safely close that PR and delete its a associated branch.
           EOF
 

--- a/release.yaml
+++ b/release.yaml
@@ -34,7 +34,7 @@ internal:
               git switch -c "${branch}"
               git commit -am 'release_patch: {{version}}' -m '{{config}}'
               git push origin ${branch}
-          - name: "gh"
+          - name: "github:pr"
             cmd: |
               gh pr create \
                 --fill \
@@ -58,7 +58,7 @@ internal:
               git switch -c "${branch}"
               git commit -am 'release_minor: {{version}}' -m '{{config}}'
               git push origin ${branch}
-          - name: "gh"
+          - name: "github:pr"
             cmd: |
               gh pr create \
                 --fill \
@@ -82,7 +82,7 @@ internal:
               git switch -c "${branch}"
               git commit -am 'release_major: {{version}}' -m '{{config}}'
               git push origin ${branch}
-          - name: "gh"
+          - name: "github:pr"
             cmd: |
               gh pr create \
                 --fill \

--- a/release.yaml
+++ b/release.yaml
@@ -105,7 +105,7 @@ internal:
           git push origin "${branch}"
           git checkout -
 
-          cat << EOF | buildkite-agent annotate --style success
+          cat << EOF | buildkite-agent annotate --style info
           Internal release is ready for promotion under the branch [\`$branch\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$branch).
           EOF
 test:
@@ -162,4 +162,6 @@ promoteToPublic:
           # TODO remove after QA
           git tag QA-{{version}}
           git push origin ${branch} --tags
-          buildkite-agent annotate 'Promoted release is **publicly available** at [`' "QA-${version}" '`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/${version})' --style 'success'
+          cat << EOF | buildkite-agent annotate --style info
+          Promoted release is **publicly available** through a git tag at [\`QA-$version\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$version).
+          EOF

--- a/release.yaml
+++ b/release.yaml
@@ -22,17 +22,17 @@ internal:
       patch:
           - name: docker(compose):tags
             cmd: |
-              set -e
+              set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
               sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
           - name: docker(shell):tags
             cmd: |
-              set -e
+              set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
               sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
-              set -e
+              set -eu
               branch="internal/release-{{version}}"
               git switch -c "${branch}"
               git commit -am 'release_patch: {{version}}' -m '{{config}}'
@@ -47,17 +47,17 @@ internal:
       minor:
           - name: docker(compose):tags
             cmd: |
-              set -e
+              set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
               sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
           - name: docker(shell):tags
             cmd: |
-              set -e
+              set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
               sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
-              set -e
+              set -eu
               branch="internal/release-{{version}}"
               git switch -c "${branch}"
               git commit -am 'release_minor: {{version}}' -m '{{config}}'
@@ -72,17 +72,17 @@ internal:
       major:
           - name: docker(compose):tags
             cmd: |
-              set -e
+              set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
               sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
           - name: docker(shell):tags
             cmd: |
-              set -e
+              set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
               sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
-              set -e
+              set -eu
               branch="internal/release-{{version}}"
               git switch -c "${branch}"
               git commit -am 'release_major: {{version}}' -m '{{config}}'
@@ -91,6 +91,7 @@ internal:
             cmd: |
               gh pr create \
                 --fill \
+                --draft \
                 --title "(internal) release_major: build {{version}}" \
                 --body "Test plan: automated release PR, CI will perform additional checks"
               echo "🚢 Please check the associated CI build to ensure the process completed".
@@ -98,13 +99,14 @@ internal:
     steps:
       - name: "git:finalize"
         cmd: |
-          set -e
+          set -eu
           # branch="ready/release-{{version}}"
           # git switch -c "${branch}"
           # echo "pushing branch ${branch}"
           # git push origin "${branch}"
           # git checkout -
           branch="internal/release-{{version}}"
+          gh pr comment "$branch" --body ":green_circle: Internal release is ready from promotion.\n:warning: Do not delete close that pull-request or delete the branch if you intend to promote that release."
           cat << EOF | buildkite-agent annotate --style info
           Internal release is ready for promotion under the branch [\`$branch\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$branch).
           EOF
@@ -119,33 +121,37 @@ promoteToPublic:
     steps:
       - name: "git"
         cmd: |
-          set -e
+          set -eu
           branch="internal/release-{{version}}"
           git fetch origin "${branch}"
           git switch "${branch}"
       - name: docker(compose):tags
         cmd: |
-          set -e
+          set -eu
           registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public
           sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
       - name: docker(shell):tags
         cmd: |
-          set -e
+          set -eu
           registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public
           sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
       - name: "git:branch"
         cmd: |
+          set -eu
           branch="promote/release-{{version}}"
           git switch -c "${branch}"
           git commit -am 'promote-release: {{version}}' -m '{{config}}'
           git push origin "${branch}"
       - name: "github:pr"
         cmd: |
-          set -e
+          set -eu
+          internal_branch="internal/release-{{version}}"
           # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
-          git fetch origin "${branch}"
+          git fetch origin "${internal_branch}"
           gh pr create \
             --fill \
+            --draft \
+            --base "$internal_branch"
             --title "(promote) release: build {{version}}" \
             --body "Test plan: automated release PR, CI will perform additional checks"
           echo "🚢 Please check the associated CI build to ensure the process completed".
@@ -153,14 +159,37 @@ promoteToPublic:
     steps:
       - name: git:tag
         cmd: |
-          set -e
-          branch="promote/release-{{version}}"
-          saved_branch="release-{{version}}"
-          git checkout "${branch}"
-          git switch -c "${saved_branch}"
+          set -eu
+
+          # Branches
+          internal_branch="internal/release-{{version}}"
+          promote_branch="promote/release-{{version}}"
+          release_branch="release-{{version}}"
+
+          # Create the final branch holding the tagged commit
+          git checkout "${promote_branch}"
+          git switch -c "${release_branch}"
           # TODO remove after QA
           git tag QA-{{version}}
-          git push origin ${saved_branch} --tags
+          git push origin ${release_branch} --tags
+
+          # Web URL to the tag
+          tag_url="https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$version"
+
+          # Annotate PRs 
+          cat << EOF | gh pr comment "$internal_branch" --body-file -
+          - :green_circle: Release has been promoted, see tag: $tag_url.
+          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (\`$release_branch\`)."
+          - :arrow_right: You can safely close that PR and delete its a associated branch.
+          EOF
+
+          cat << EOF | gh pr comment "$promote_branch" --body-file -
+          - :green_circle: Release has been promoted, see tag: $tag_url.
+          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (\`$release_branch\`)."
+          - :arrow_right: You can safely close that PR and delete its a associated branch.
+          EOF
+
+          # Annotate build
           cat << EOF | buildkite-agent annotate --style info
           Promoted release is **publicly available** through a git tag at [\`QA-$version\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$version).
           EOF

--- a/release.yaml
+++ b/release.yaml
@@ -134,6 +134,7 @@ promoteToPublic:
             --title "(promote) release: build {{version}}" \
             --base "${branch}" \
             --body "Test plan: automated release PR, CI will perform additional checks"
+          echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:
     steps:
       - name: git:tag

--- a/release.yaml
+++ b/release.yaml
@@ -104,6 +104,7 @@ internal:
           echo "pushing branch ${branch}"
           git push origin "${branch}"
           git checkout -
+          buildkite-agent annotate "Internal release is ready for promotion under the branch [`${branch}](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/${branch})` style" --style 'success' --context 'ctx-success'
 test:
   steps:
     - name: "Placeholder"
@@ -141,6 +142,7 @@ promoteToPublic:
           branch="ready/release-{{version}}"
           # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
           git fetch origin "${branch}"
+          git switch "${branch}"
           gh pr create \
             --fill \
             --title "(promote) release: build {{version}}" \
@@ -157,3 +159,4 @@ promoteToPublic:
           # TODO remove after QA
           git tag QA-{{version}}
           git push origin ${branch} --tags
+          buildkite-agent annotate "Promoted release is publicly available at [`QA-${version}](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/QA-${version})` style" --style 'success' --context 'ctx-success'

--- a/release.yaml
+++ b/release.yaml
@@ -102,11 +102,7 @@ internal:
       - name: "git:finalize"
         cmd: |
           set -eu
-          # branch="ready/release-{{version}}"
-          # git switch -c "${branch}"
-          # echo "pushing branch ${branch}"
-          # git push origin "${branch}"
-          # git checkout -
+
           branch="internal/release-{{version}}"
 
           # Post a comment on the PR.

--- a/release.yaml
+++ b/release.yaml
@@ -104,7 +104,7 @@ internal:
           echo "pushing branch ${branch}"
           git push origin "${branch}"
           git checkout -
-          buildkite-agent annotate "Internal release is ready for promotion under the branch [`${branch}](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/${branch})` style" --style 'success' --context 'ctx-success'
+          buildkite-agent 'Internal release is ready for promotion under the branch [`' "${branch}" '`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/${branch})' --style 'success'
 test:
   steps:
     - name: "Placeholder"
@@ -159,4 +159,4 @@ promoteToPublic:
           # TODO remove after QA
           git tag QA-{{version}}
           git push origin ${branch} --tags
-          buildkite-agent annotate "Promoted release is publicly available at [`QA-${version}](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/QA-${version})` style" --style 'success' --context 'ctx-success'
+          buildkite-agent 'Promoted release is **publicly available** at [`' "QA-${version}" '`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/${version})' --style 'success'

--- a/release.yaml
+++ b/release.yaml
@@ -99,12 +99,12 @@ internal:
       - name: "git:finalize"
         cmd: |
           set -e
-          branch="ready/release-{{version}}"
-          git switch -c "${branch}"
-          echo "pushing branch ${branch}"
-          git push origin "${branch}"
-          git checkout -
-
+          # branch="ready/release-{{version}}"
+          # git switch -c "${branch}"
+          # echo "pushing branch ${branch}"
+          # git push origin "${branch}"
+          # git checkout -
+          branch="internal/release-{{version}}"
           cat << EOF | buildkite-agent annotate --style info
           Internal release is ready for promotion under the branch [\`$branch\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$branch).
           EOF

--- a/release.yaml
+++ b/release.yaml
@@ -106,7 +106,14 @@ internal:
           # git push origin "${branch}"
           # git checkout -
           branch="internal/release-{{version}}"
-          gh pr comment "$branch" --body ":green_circle: Internal release is ready from promotion.\n:warning: Do not delete close that pull-request or delete the branch if you intend to promote that release."
+
+          # Post a comment on the PR.
+          cat << EOF | gh pr comment "$branch" --body-file -
+          - :green_circle: Interal release is ready for promotion!
+          - :warning: Do not close/merge that pull request or delete the associated branch if you intend to promote it.
+          EOF
+
+          # Post an annotation.
           cat << EOF | buildkite-agent annotate --style info
           Internal release is ready for promotion under the branch [\`$branch\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$branch).
           EOF

--- a/release.yaml
+++ b/release.yaml
@@ -104,7 +104,10 @@ internal:
           echo "pushing branch ${branch}"
           git push origin "${branch}"
           git checkout -
-          buildkite-agent annotate 'Internal release is ready for promotion under the branch [`' "${branch}" '`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/${branch})' --style 'success'
+
+          cat << EOF | buildkite-agent annotate --style success
+          Internal release is ready for promotion under the branch [\`$branch\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$branch).
+          EOF
 test:
   steps:
     - name: "Placeholder"

--- a/release.yaml
+++ b/release.yaml
@@ -158,7 +158,7 @@ promoteToPublic:
           gh pr create \
             --fill \
             --draft \
-            --base "$internal_branch"
+            --base "$internal_branch" \
             --title "(promote) release: build {{version}}" \
             --body "Test plan: automated release PR, CI will perform additional checks"
           echo "🚢 Please check the associated CI build to ensure the process completed".

--- a/release.yaml
+++ b/release.yaml
@@ -5,7 +5,7 @@ meta:
     - "@sourcegraph/release"
   repository: "github.com/sourcegraph/deploy-sourcegraph-docker"
 inputs:
-  releaseId: server
+  - releaseId: server
 requirements:
   - name: "go"
     cmd: "which go"
@@ -29,13 +29,17 @@ internal:
               sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
-              branch="wip_{{version}}"
+              set -e
+              branch="internal/release-{{version}}"
               git switch -c "${branch}"
               git commit -am 'release_patch: {{version}}' -m '{{config}}'
               git push origin ${branch}
           - name: "gh"
             cmd: |
-              gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
+              gh pr create \
+                --fill \
+                --title "(internal) release_patch: build {{version}}" \
+                --body "Test plan: automated release PR, CI will perform additional checks" 
       minor:
           - name: docker(compose):tags
             cmd: |
@@ -49,13 +53,17 @@ internal:
               sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
-              branch="wip_{{version}}"
+              set -e
+              branch="internal/release-{{version}}"
               git switch -c "${branch}"
               git commit -am 'release_minor: {{version}}' -m '{{config}}'
               git push origin ${branch}
           - name: "gh"
             cmd: |
-              gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
+              gh pr create \
+                --fill \
+                --title "(internal) release_minor: build {{version}}" \
+                --body "Test plan: automated release PR, CI will perform additional checks"
       major:
           - name: docker(compose):tags
             cmd: |
@@ -69,26 +77,30 @@ internal:
               sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
           - name: "git:branch"
             cmd: |
-              branch="wip_{{version}}"
+              set -e
+              branch="internal/release-{{version}}"
               git switch -c "${branch}"
               git commit -am 'release_major: {{version}}' -m '{{config}}'
               git push origin ${branch}
           - name: "gh"
             cmd: |
-              gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
+              gh pr create \
+                --fill \
+                --title "(internal) release_major: build {{version}}" \
+                --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
       - name: "git:finalize"
         cmd: |
           set -e
-          branch="wip_release-{{version}}"
+          branch="release-{{version}}"
           git switch -c "${branch}"
           echo "pushing branch ${branch}"
           git push origin "${branch}"
           git checkout -
 test:
   steps:
-    - name: "foo"
+    - name: "Placeholder"
       cmd: |
         echo "Test"
 
@@ -107,23 +119,28 @@ promoteToPublic:
           sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
       - name: "git:branch"
         cmd: |
-          branch="promote-release_{{version}}"
+          branch="promote/release-{{version}}"
           git switch -c "${branch}"
           git commit -am 'promote-release: {{version}}' -m '{{config}}'
           git push origin "${branch}"
-      - name: "gh"
+      - name: "github:pr"
         cmd: |
           set -e
-          branch="wip_release-{{version}}"
+          branch="internal/release-{{version}}"
           # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
           git fetch origin "${branch}"
-          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${branch}" --body "Test plan: automated release PR, CI will perform additional checks"
+          gh pr create \
+            --fill \
+            --title "(promote) release: build {{version}}" \
+            --base "${branch}" \
+            --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
       - name: git:tag
         cmd: |
           set -e
-          branch="wip_release-{{version}}"
+          branch="promote/release-{{version}}"
           git checkout "${branch}"
-          git tag wip_{{version}}
+          # TODO remove after QA
+          git tag QA-{{version}}
           git push origin ${branch} --tags

--- a/release.yaml
+++ b/release.yaml
@@ -104,7 +104,7 @@ internal:
           echo "pushing branch ${branch}"
           git push origin "${branch}"
           git checkout -
-          buildkite-agent 'Internal release is ready for promotion under the branch [`' "${branch}" '`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/${branch})' --style 'success'
+          buildkite-agent annotate 'Internal release is ready for promotion under the branch [`' "${branch}" '`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/${branch})' --style 'success'
 test:
   steps:
     - name: "Placeholder"
@@ -159,4 +159,4 @@ promoteToPublic:
           # TODO remove after QA
           git tag QA-{{version}}
           git push origin ${branch} --tags
-          buildkite-agent 'Promoted release is **publicly available** at [`' "QA-${version}" '`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/${version})' --style 'success'
+          buildkite-agent annotate 'Promoted release is **publicly available** at [`' "QA-${version}" '`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/${version})' --style 'success'

--- a/release.yaml
+++ b/release.yaml
@@ -160,7 +160,7 @@ promoteToPublic:
           git switch -c "${saved_branch}"
           # TODO remove after QA
           git tag QA-{{version}}
-          git push origin ${branch} --tags
+          git push origin ${saved_branch} --tags
           cat << EOF | buildkite-agent annotate --style info
           Promoted release is **publicly available** through a git tag at [\`QA-$version\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$version).
           EOF

--- a/release.yaml
+++ b/release.yaml
@@ -43,6 +43,7 @@ internal:
                 --fill \
                 --title "(internal) release_patch: build {{version}}" \
                 --body "Test plan: automated release PR, CI will perform additional checks" 
+              echo "🚢 Please check the associated CI build to ensure the process completed".
       minor:
           - name: docker(compose):tags
             cmd: |
@@ -67,6 +68,7 @@ internal:
                 --fill \
                 --title "(internal) release_minor: build {{version}}" \
                 --body "Test plan: automated release PR, CI will perform additional checks"
+              echo "🚢 Please check the associated CI build to ensure the process completed".
       major:
           - name: docker(compose):tags
             cmd: |
@@ -97,7 +99,7 @@ internal:
       - name: "git:finalize"
         cmd: |
           set -e
-          branch="release-{{version}}"
+          branch="ready/release-{{version}}"
           git switch -c "${branch}"
           echo "pushing branch ${branch}"
           git push origin "${branch}"
@@ -111,6 +113,12 @@ test:
 promoteToPublic:
   create:
     steps:
+      - name: "git"
+        cmd: |
+          set -e
+          branch="ready/release-{{version}}"
+          git fetch origin "${branch}"
+          git switch "${branch}"
       - name: docker(compose):tags
         cmd: |
           set -e
@@ -130,7 +138,7 @@ promoteToPublic:
       - name: "github:pr"
         cmd: |
           set -e
-          branch="internal/release-{{version}}"
+          branch="ready/release-{{version}}"
           # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
           git fetch origin "${branch}"
           gh pr create \

--- a/release.yaml
+++ b/release.yaml
@@ -142,13 +142,11 @@ promoteToPublic:
       - name: "github:pr"
         cmd: |
           set -e
-          base_branch="ready/release-{{version}}"
           # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
           git fetch origin "${branch}"
           gh pr create \
             --fill \
             --title "(promote) release: build {{version}}" \
-            --base "${base_branch}" \
             --body "Test plan: automated release PR, CI will perform additional checks"
           echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:
@@ -157,7 +155,9 @@ promoteToPublic:
         cmd: |
           set -e
           branch="promote/release-{{version}}"
+          saved_branch="release-{{version}}"
           git checkout "${branch}"
+          git switch -c "${saved_branch}"
           # TODO remove after QA
           git tag QA-{{version}}
           git push origin ${branch} --tags

--- a/release.yaml
+++ b/release.yaml
@@ -41,6 +41,7 @@ internal:
             cmd: |
               gh pr create \
                 --fill \
+                --draft \
                 --title "(internal) release_patch: build {{version}}" \
                 --body "Test plan: automated release PR, CI will perform additional checks" 
               echo "🚢 Please check the associated CI build to ensure the process completed".
@@ -66,6 +67,7 @@ internal:
             cmd: |
               gh pr create \
                 --fill \
+                --draft \
                 --title "(internal) release_minor: build {{version}}" \
                 --body "Test plan: automated release PR, CI will perform additional checks"
               echo "🚢 Please check the associated CI build to ensure the process completed".

--- a/release.yaml
+++ b/release.yaml
@@ -14,6 +14,9 @@ requirements:
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
 internal:
+  # Please keep in mind that the CI pipeline uses the branch names defined below when creating releases.
+  # Therefore, if you update them, or if you decide to change how we detect what kind of build we're dealing
+  # with, please update this file as well.
   create:
     steps:
       patch:
@@ -88,6 +91,7 @@ internal:
                 --fill \
                 --title "(internal) release_major: build {{version}}" \
                 --body "Test plan: automated release PR, CI will perform additional checks"
+              echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:
     steps:
       - name: "git:finalize"


### PR DESCRIPTION
Add the final layer of paint + QA (internal+promotion). 

I reworked how we handle branches, so we have the simplest and safest approach for the next few release cycles: 

- creating an internal release: 
  - `<any branch>` -> `internal/release-vX.Y.Z` 
  - opens a PR (ex: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/1019)
  - CI build 
  - once it reaches the finalization step in CI, it posts a message in the PR indicating that it's ready for promotion. 
- promoting a release:   
  - `internal/release-vX.Y.Z` -> `promote/release-vX.Y.Z`
  - opens a PR (ex: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/1020) 
  - CI build 
  - once it reaches the finalization step in CI: 
    - create a branch from `promote/release-vX.Y.Z` to `release-vX.Y.Z`
    - it posts a message in the PR indicating that it's been publicly released and that PRs can be safely closed (on both the promotion PR and the public one) 
    - tags the commit from the `release-vX.Y.Z` branch. 

The previous flow was: 

- from any branch, `sg release create ...` would checkout a new branch named `wip_vX.Y.Z` 
- a PR is created, trigger a CI run for the internal release. 
  -  at the very end of the run, the `finalize` step would create a new branch named `wip-release-vX.Y.Z` 
- from any branch `sg release promote-to-public` would checkout a new branch named `promote-release_vX.Y.Z` 
  - a PR is created, targeting `wip-release-vX.Y.Z` as the base branch, triggering a CI build for the promotion 
    - there was a bug, you could end up accidentally creating a branch that can't be merged into that base. It works if you're running that command from the internal branch but may not otherwise. 
    - at the very end of the run, the `finalize` step would tag the commit. 

Problem: if you decide to merge the final branch that has the tagged commit, you'd end up with a dangling commit, which is risky/scary. This passed the review because back then we overlooked the fact that it's very to just close the PR, to keep things tidy. 





### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan

<img width="2493" alt="image" src="https://github.com/sourcegraph/deploy-sourcegraph-docker/assets/10151/c97a6958-577d-45de-9a64-0eea68565ce8">

![CleanShot 2024-03-22 at 14 07 32@2x](https://github.com/sourcegraph/deploy-sourcegraph-docker/assets/10151/051d3d7f-0edf-40b7-8458-45363efc6b56)

![CleanShot 2024-03-22 at 14 07 48@2x](https://github.com/sourcegraph/deploy-sourcegraph-docker/assets/10151/aa9d77b4-ee28-4fcd-a4a6-8715c06490c4)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
