### PR TITLE
fix(rel): use inputs.server.tag instead of tag

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -24,12 +24,12 @@ internal:
             cmd: |
               set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+              sg ops update-images --registry ${registry} --kind compose --pin-tag {{inputs.server.tag}} docker-compose/
           - name: docker(shell):tags
             cmd: |
               set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
+              sg ops update-images --registry ${registry} --kind shell --pin-tag {{inputs.server.tag}} pure-docker/
           - name: "git:branch"
             cmd: |
               set -eu
@@ -50,12 +50,12 @@ internal:
             cmd: |
               set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+              sg ops update-images --registry ${registry} --kind compose --pin-tag {{inputs.server.tag}} docker-compose/
           - name: docker(shell):tags
             cmd: |
               set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
+              sg ops update-images --registry ${registry} --kind shell --pin-tag {{inputs.server.tag}} pure-docker/
           - name: "git:branch"
             cmd: |
               set -eu
@@ -76,12 +76,12 @@ internal:
             cmd: |
               set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+              sg ops update-images --registry ${registry} --kind compose --pin-tag {{inputs.server.tag}} docker-compose/
           - name: docker(shell):tags
             cmd: |
               set -eu
               registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
-              sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
+              sg ops update-images --registry ${registry} --kind shell --pin-tag {{inputs.server.tag}} pure-docker/
           - name: "git:branch"
             cmd: |
               set -eu
@@ -134,12 +134,12 @@ promoteToPublic:
         cmd: |
           set -eu
           registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public
-          sg ops update-images --registry ${registry} --kind compose --pin-tag {{tag}} docker-compose/
+          sg ops update-images --registry ${registry} --kind compose --pin-tag {{inputs.server.tag}} docker-compose/
       - name: docker(shell):tags
         cmd: |
           set -eu
           registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public
-          sg ops update-images --registry ${registry} --kind shell --pin-tag {{tag}} pure-docker/
+          sg ops update-images --registry ${registry} --kind shell --pin-tag {{inputs.server.tag}} pure-docker/
       - name: "git:branch"
         cmd: |
           set -eu


### PR DESCRIPTION
Noticed we were using `{{tag}}` instead of `{{inputs.server.tag}}` which works as long as every internal release has the same version as the original sourcegraph one. 

This PR fixes that.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan

![CleanShot 2024-04-03 at 11 54 55@2x](https://github.com/sourcegraph/deploy-sourcegraph-docker/assets/10151/a7996269-c71d-4e74-befc-1258cabdc196)

See https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/1022

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
