### PR TITLE
Replace upstream caddy with internal version

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
   # https://caddyserver.com/docs/caddyfile
   caddy:
     container_name: caddy
-    image: 'index.docker.io/caddy:2.7.6-alpine@sha256:80ca561981768b2c3568cc4bef3d4cd1f11c2a625c806bedeb8453aef98779a0'
+    image: 'index.docker.io/sourcegraph/caddy:269106_2024-04-15_5.3-d8deee19f4ae@sha256:13b9ee03ca9feba90d83129922f96ee9c1b40064a048b73feac3a334e27c3aa1'
     cpus: 4
     mem_limit: '4g'
     environment:

--- a/pure-docker/deploy-caddy.sh
+++ b/pure-docker/deploy-caddy.sh
@@ -32,4 +32,4 @@ docker run --detach \
   -p 0.0.0.0:443:443 \
   -v "$VOLUME:/caddy-storage" \
   --mount type=bind,source="$(pwd)"/../caddy/builtins/http.Caddyfile,target=/etc/caddy/Caddyfile \
-  index.docker.io/caddy:2.7.6-alpine@sha256:80ca561981768b2c3568cc4bef3d4cd1f11c2a625c806bedeb8453aef98779a0
+  index.docker.io/sourcegraph/caddy:269106_2024-04-15_5.3-d8deee19f4ae@sha256:13b9ee03ca9feba90d83129922f96ee9c1b40064a048b73feac3a334e27c3aa1


### PR DESCRIPTION
<!-- description here -->
Now that we have a custom-built caddy image, replace the upstream reference with our custom one.

The `269106_2024-04-15_5.3-d8deee19f4ae` tag I've used is just from a [standard Buildkite run on main](https://buildkite.com/sourcegraph/sourcegraph/builds/269106#018ee287-0c9b-4f39-86a6-3d73fa98a0e1) - I assume it's just a placeholder that will be overwritten when we run each release?

Confirmed that `sg ops update-images` works:

```
$ bazel run //dev/sg -- ops update-images --pin-tag insiders --kind compose --registry internal ~/code/deploy-sourcegraph-docke
r/docker-compose/

[...]
Updated caddy
  - docker.io/sourcegraph/caddy:269106_2024-04-15_5.3-d8deee19f4ae@sha256:13b9ee03ca9feba90d83129922f96ee9c1b40064a048b73feac3a334e27c3aa1
  + us.gcr.io/sourcegraph-dev/caddy:insiders@sha256:13b9ee03ca9feba90d83129922f96ee9c1b40064a048b73feac3a334e27c3aa1
[...]
```

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [x] All images have a valid tag and SHA256 sum
### Test plan

- [x] Tested running the docker-compose setup locally with new caddy image
- [x] Tested running the pure-docker setup locally with new caddy image
- [x] Tested `sg ops update-images`

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
