### PR TITLE
fix(otel): Update Jaeger for OTEL changes

### DIFF
--- a/docker-compose/jaeger/docker-compose.yaml
+++ b/docker-compose/jaeger/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
   #
   jaeger:
     container_name: jaeger
-    image: 'index.docker.io/sourcegraph/jaeger-all-in-one:281057_2024-07-04_5.4-b98c7d084d30:3ff2c29a456f4b275a46ca413eb38c84ee9df6109460691b13a798aecee038a0'
+    image: 'index.docker.io/sourcegraph/jaeger-all-in-one:281057_2024-07-04_5.4-b98c7d084d30@sha256:3ff2c29a456f4b275a46ca413eb38c84ee9df6109460691b13a798aecee038a0'
     cpus: 0.5
     mem_limit: '512m'
     ports:

--- a/docker-compose/jaeger/docker-compose.yaml
+++ b/docker-compose/jaeger/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # (https://www.jaegertracing.io/docs/1.17/getting-started/#all-in-one) for distributed tracing.
   #
   # Disk: none
-  # Ports exposed to other Sourcegraph services: 5778/TCP 6831/UDP 6832/UDP 14250/TCP
+  # Ports exposed to other Sourcegraph services: 5778/TCP 6831/UDP 6832/UDP 14250/TCP 4320/UDP 4321/UDP
   # Ports exposed to the public internet: none
   # Ports exposed to site admins only: 16686/HTTP
   #

--- a/docker-compose/jaeger/docker-compose.yaml
+++ b/docker-compose/jaeger/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
   #
   jaeger:
     container_name: jaeger
-    image: 'index.docker.io/sourcegraph/jaeger-all-in-one:216430_2023-05-02_5.0-3cc9006de32c@sha256:ec73cff6ea398d96241a9451634fc83682292b0175cc63c09f1f866cf03beb8d'
+    image: 'index.docker.io/sourcegraph/jaeger-all-in-one:281057_2024-07-04_5.4-b98c7d084d30:3ff2c29a456f4b275a46ca413eb38c84ee9df6109460691b13a798aecee038a0'
     cpus: 0.5
     mem_limit: '512m'
     ports:
@@ -18,6 +18,8 @@ services:
       - '0.0.0.0:16686:16686'
       # Collector port
       - '0.0.0.0:14250:14250'
+      - '0.0.0.0:4320:4320' # gRPC port
+      - '0.0.0.0:4321:4321' # HTTP port
       # Agent ports
       - '0.0.0.0:5778:5778'
       - '0.0.0.0:6831:6831'
@@ -25,14 +27,18 @@ services:
     networks:
       - sourcegraph
     restart: always
-    command: ['--memory.max-traces=20000']
+    command: ['--memory.max-traces=20000', "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json", "--collector.otlp.enabled" ]
     environment:
       - 'SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json'
+      - 'COLLECTOR_OTLP_ENABLED=true'
+      - 'JAEGER_OTLP_GRPC_PORT=4320'
+      - 'JAEGER_OTLP_HTTP_PORT=4321'
 
   # Configure collector to send traces to Jaeger
   otel-collector:
     environment:
       - JAEGER_HOST=jaeger
+      - JAEGER_OTLP_GRPC_PORT=4320
     command: ['--config', '/etc/otel-collector/configs/jaeger.yaml']
 
   # Let frontend proxy to Jaeger interface

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -4,8 +4,8 @@
 receivers:
   otlp:
     protocols:
-      grpc: # port 4317
-      http: # port 4318
+      grpc: # port 4320
+      http: # port 4321
 
 exporters:
   # Add your exporter(s) configuration here. For each exporter, make sure it is enabled


### PR DESCRIPTION
- **fix(otel): update jaeger-all-in-one to support otel defaults**
- **docs(jaeger): add docs for more exposed ports**
- **fix(jaeger): fix image hash**

Related to [REL-166](https://linear.app/sourcegraph/issue/REL-166/cve-2024-36129-update-jaeger-and-otel-in-deploy-repos)

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:  #b8e356a2
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):  #3d04c16d
* [ ] All images have a valid tag and SHA256 sum  #ecb24509
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Manual Testing
