### PR TITLE
chore: update image to latest

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,6 +1,7 @@
 $schema: "http://json.schemastore.org/buildkite"
 env:
-  IMAGE: "e2e-0040635f0-2022-03-16t17-33-08z"
+  # Build this image in sourcegraph/infrastructure by running `make e2e` in `gcp/images`
+  IMAGE: "e2e-db8a40720-2024-08-26t08-44-10z"
   VAGRANT_RUN_ENV: "CI"
 steps:
   - label: ":docker:"


### PR DESCRIPTION
Recently a bunch of images were deleted from the `sourcegraph-ci` to free up quota. The e2e image wasn't used in over 2 years hence it was deleted. This updates the pipeline to use the latest image.

How to build the image:
1. checkout `sourcegraph/infrastructure`
2. `cd gcp/images`
3. Make sure you have the right entitle permissions for `sourcegraph-ci` ... DevX bundle covers this
4. `make e2e`

### Test plan
CI
