### PR TITLE
Adding pgsql datasource for Grafana

### DIFF
--- a/grafana/datasources/datasources-pgsql.yaml
+++ b/grafana/datasources/datasources-pgsql.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: pgsql
+    type: postgres
+    url: $PGHOST:$PGPORT
+    user: $PGGRAFANAUSER
+    database: $PGDATABASE
+    secureJsonData:
+      password: $PGGRAFANAPASSWORD
+    jsonData:
+      sslmode: $PGSSLMODE


### PR DESCRIPTION
For [PS-83: Create pgsql datasource in Grafana](https://linear.app/sourcegraph/issue/PS-83/create-pgsql-datasource-in-grafana)

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Tested on test instance, with and without env vars configured

### Alternatives Considered
Managing the postgres datasource as a separate file in the datasources directory is preferred over adding it as another datasource in the existing file, and as Docker Compose mounts an entire directory to a directory, this works just fine.