### PR TITLE
chore: Keep env var names consistent for Grafana pgsql datasource

### DIFF
--- a/grafana/datasources/datasources-pgsql.yaml
+++ b/grafana/datasources/datasources-pgsql.yaml
@@ -3,10 +3,10 @@ apiVersion: 1
 datasources:
   - name: pgsql
     type: postgres
-    url: $PGHOST:$PGPORT
-    user: $PGGRAFANAUSER
-    database: $PGDATABASE
+    url: $GRAFANA_PGSQL_HOST:$GRAFANA_PGSQL_PORT
+    user: $GRAFANA_PGSQL_USER
+    database: $GRAFANA_PGSQL_DATABASE
     secureJsonData:
-      password: $PGGRAFANAPASSWORD
+      password: $GRAFANA_PGSQL_PASSWORD
     jsonData:
-      sslmode: $PGSSLMODE
+      sslmode: $GRAFANA_PGSQL_SSLMODE


### PR DESCRIPTION
<!-- description here -->

While implementing these creds as Kubernetes secrets in the deploy-sourcegraph-helm repo in https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/568, the name of the env vars changed to match the format in the databaseAuth Helm template helper function, so I'm just updating the env var names to keep them consistent.

Issue:
https://linear.app/sourcegraph/issue/PS-91/update-env-vars-in-sgsg-to-match-helm-format

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Manual testing