### PR TITLE
fix: use postgresql 16 images

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -553,7 +553,7 @@ services:
   #
   pgsql:
     container_name: pgsql
-    image: 'index.docker.io/sourcegraph/postgres-12-alpine:5.9.1590@sha256:3d5dd36e3af6b643903f507422be19ed1cb1f5f71c4541572d4a8a252e81aeb8'
+    image: 'index.docker.io/sourcegraph/postgresql-16:insiders'
     cpus: 4
     mem_limit: '4g'
     shm_size: '1g'
@@ -600,7 +600,7 @@ services:
   #
   codeintel-db:
     container_name: codeintel-db
-    image: 'index.docker.io/sourcegraph/codeintel-db:5.9.1590@sha256:3d5dd36e3af6b643903f507422be19ed1cb1f5f71c4541572d4a8a252e81aeb8'
+    image: 'index.docker.io/sourcegraph/postgresql-16:insiders'
     cpus: 4
     mem_limit: '4g'
     shm_size: '1g'
@@ -647,7 +647,7 @@ services:
   #
   codeinsights-db:
     container_name: codeinsights-db
-    image: 'index.docker.io/sourcegraph/codeinsights-db:5.9.1590@sha256:4e75b2c463ce1ef3bfeec4bb71a16693df02005e66b9e697859ce61064e08f42'
+    image: 'index.docker.io/sourcegraph/postgresql-16-codeinsights:insiders'
     cpus: 4
     mem_limit: '2g'
     shm_size: '1g'

--- a/pure-docker/deploy-codeinsights-db.sh
+++ b/pure-docker/deploy-codeinsights-db.sh
@@ -13,17 +13,17 @@ VOLUME="$HOME/sourcegraph-docker/codeinsights-db-disk"
 ./ensure-volume.sh $VOLUME 999
 
 docker run --detach \
-    --name=codeinsights-db \
-    --network=sourcegraph \
-    --restart=always \
-    --cpus=4 \
-    --memory=2g \
-    -e POSTGRES_DB=postgres \
-    -e POSTGRES_PASSWORD=password \
-    -e POSTGRES_USER=postgres \
-    -e PGDATA=/var/lib/postgresql/data/pgdata \
-    -v $VOLUME:/var/lib/postgresql/data/ \
-    index.docker.io/sourcegraph/codeinsights-db:187572_2022-12-06_cbecc5321c7d@sha256:4dd89a1279e7d55ddcb5b570d0bb544422dd1ecb0e3662f23d22f9643837c2b5
+  --name=codeinsights-db \
+  --network=sourcegraph \
+  --restart=always \
+  --cpus=4 \
+  --memory=2g \
+  -e POSTGRES_DB=postgres \
+  -e POSTGRES_PASSWORD=password \
+  -e POSTGRES_USER=postgres \
+  -e PGDATA=/var/lib/postgresql/data/pgdata \
+  -v $VOLUME:/var/lib/postgresql/data/ \
+  index.docker.io/sourcegraph/postgresql-16-codeinsights:insiders
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,
 # but anything 12 and higher is supported.

--- a/pure-docker/deploy-codeintel-db.sh
+++ b/pure-docker/deploy-codeintel-db.sh
@@ -12,14 +12,14 @@ set -e
 VOLUME="$HOME/sourcegraph-docker/codeintel-db-disk"
 ./ensure-volume.sh $VOLUME 999
 docker run --detach \
-    --name=codeintel-db \
-    --network=sourcegraph \
-    --restart=always \
-    --cpus=4 \
-    --memory=2g \
-    -e PGDATA=/var/lib/postgresql/data/pgdata \
-    -v $VOLUME:/var/lib/postgresql/data/ \
-    index.docker.io/sourcegraph/codeintel-db:187572_2022-12-06_cbecc5321c7d@sha256:7fb02a9392ce4dd3d4210dbd5792c09c4210a2dfc6dc389ed679137784359102
+  --name=codeintel-db \
+  --network=sourcegraph \
+  --restart=always \
+  --cpus=4 \
+  --memory=2g \
+  -e PGDATA=/var/lib/postgresql/data/pgdata \
+  -v $VOLUME:/var/lib/postgresql/data/ \
+  index.docker.io/sourcegraph/postgresql-16:insiders
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,
 # but anything 12 and higher is supported.

--- a/pure-docker/deploy-pgsql.sh
+++ b/pure-docker/deploy-pgsql.sh
@@ -12,14 +12,14 @@ set -e
 VOLUME="$HOME/sourcegraph-docker/pgsql-disk"
 ./ensure-volume.sh $VOLUME 999
 docker run --detach \
-    --name=pgsql \
-    --network=sourcegraph \
-    --restart=always \
-    --cpus=4 \
-    --memory=2g \
-    -e PGDATA=/var/lib/postgresql/data/pgdata \
-    -v $VOLUME:/var/lib/postgresql/data/ \
-    index.docker.io/sourcegraph/postgres-12-alpine:187572_2022-12-06_cbecc5321c7d@sha256:44f6e9a51fafb99573cbd767f20f68913db5a02920c5974e4fa560735d745328
+  --name=pgsql \
+  --network=sourcegraph \
+  --restart=always \
+  --cpus=4 \
+  --memory=2g \
+  -e PGDATA=/var/lib/postgresql/data/pgdata \
+  -v $VOLUME:/var/lib/postgresql/data/ \
+  index.docker.io/sourcegraph/postgresql-16:insiders
 
 # Sourcegraph requires PostgreSQL 12+. Generally newer versions are better,
 # but anything 12 and higher is supported.


### PR DESCRIPTION
We need to use the new postgresql images

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [x] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [x] All images have a valid tag and SHA256 sum
### Test plan
CI
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
