### PR TITLE
Fix Jaeger ports for HTTP tracing

### DIFF
--- a/docker-compose/jaeger/docker-compose.yaml
+++ b/docker-compose/jaeger/docker-compose.yaml
@@ -27,18 +27,20 @@ services:
     networks:
       - sourcegraph
     restart: always
-    command: ['--memory.max-traces=20000', "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json", "--collector.otlp.enabled" ]
-    environment:
-      - 'SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json'
-      - 'COLLECTOR_OTLP_ENABLED=true'
-      - 'JAEGER_OTLP_GRPC_PORT=4320'
-      - 'JAEGER_OTLP_HTTP_PORT=4321'
+    command: [
+      '--memory.max-traces=20000', 
+      "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json", 
+      "--collector.otlp.enabled",
+      "--collector.otlp.grpc.host-port=:4320",
+      "--collector.otlp.http.host-port=:4321"
+    ]
 
   # Configure collector to send traces to Jaeger
   otel-collector:
     environment:
       - JAEGER_HOST=jaeger
       - JAEGER_OTLP_GRPC_PORT=4320
+      - JAEGER_OTLP_HTTP_PORT=4321
     command: ['--config', '/etc/otel-collector/configs/jaeger.yaml']
 
   # Let frontend proxy to Jaeger interface

--- a/docker-compose/jaeger/docker-compose.yaml
+++ b/docker-compose/jaeger/docker-compose.yaml
@@ -18,8 +18,8 @@ services:
       - '0.0.0.0:16686:16686'
       # Collector port
       - '0.0.0.0:14250:14250'
-      - '0.0.0.0:4320:4320' # gRPC port
-      - '0.0.0.0:4321:4321' # HTTP port
+      - '0.0.0.0:4320:4320' # gRPC
+      - '0.0.0.0:4321:4321' # HTTP
       # Agent ports
       - '0.0.0.0:5778:5778'
       - '0.0.0.0:6831:6831'
@@ -28,8 +28,8 @@ services:
       - sourcegraph
     restart: always
     command: [
-      '--memory.max-traces=20000', 
-      "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json", 
+      '--memory.max-traces=20000',
+      "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json",
       "--collector.otlp.enabled",
       "--collector.otlp.grpc.host-port=:4320",
       "--collector.otlp.http.host-port=:4321"


### PR DESCRIPTION
Updating Docker repo to match the fix in the Helm repo from a few months ago, so that otel-collector is sending trace data to Jaeger on the same port that Jaeger is listening on. 

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan

Tested manually

`docker-compose -f docker-compose.yaml -f jaeger/docker-compose.yaml -f override.yaml up -d --remove-orphans`
