### PR TITLE
[REL-961] Close Grafana port from outside access

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -192,7 +192,7 @@ services:
       - 'SYMBOLS_URL=http://symbols-0:3184'
       - 'INDEXED_SEARCH_SERVERS=zoekt-webserver-0:6070'
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
-      - 'GRAFANA_SERVER_URL=http://grafana:3000'
+      - 'GRAFANA_SERVER_URL=http://grafana:3370'
       - 'PROMETHEUS_URL=http://prometheus:9090'
       - 'PRECISE_CODE_INTEL_UPLOAD_BACKEND=blobstore'
       - 'PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT=http://blobstore:9000'
@@ -481,8 +481,6 @@ services:
       - 'grafana:/var/lib/grafana'
       - '../grafana/datasources:/sg_config_grafana/provisioning/datasources'
       - '../grafana/dashboards:/sg_grafana_additional_dashboards'
-    ports:
-      - '0.0.0.0:3370:3370'
     networks:
       - sourcegraph
     restart: always

--- a/pure-docker/deploy-grafana.sh
+++ b/pure-docker/deploy-grafana.sh
@@ -17,7 +17,6 @@ docker run --detach \
     --restart=always \
     --cpus=1 \
     --memory=1g \
-    -p 0.0.0.0:3370:3370 \
     -v $VOLUME:/var/lib/grafana \
     -v $(pwd)/../grafana/datasources:/sg_config_grafana/provisioning/datasources \
     -v $(pwd)/../grafana/dashboards:/sg_grafana_additional_dashboards \


### PR DESCRIPTION
<!-- description here -->


[REL-961 Review Docker Compose file for Grafana port exposure security](https://linear.app/sourcegraph/issue/REL-961/review-docker-compose-file-for-grafana-port-exposure-security)

Is there any particular reason why we have the Grafana port 3370 open for side channel access? It seems like it's been open since Grafana was first bundled with the product in https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/51ca07933b2149f3fb038b8969d95d4be8843756, even though the reverse proxy was implemented at about the same time, in https://github.com/sourcegraph/sourcegraph/commit/939b612fb319f6563116f4bcd5814dc486f78361

I suggest we close the side channel access, to reduce exposure for customers running the Airgapped Analytics dashboard. 

Also, fixed a broken port number in sourcegraph-frontend-internal's config for the Grafana URL, which has been broken since https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/f6f8d8dff29335a4a96133b58edb0d931415fca9, so probably not used. 


### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan

Tested on test instance, frontend still proxies the connection to Grafana as needed, without side channel access

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
