### PR TITLE
chore(ci): login with docker

### DIFF
--- a/.buildkite/ci-checkov.sh
+++ b/.buildkite/ci-checkov.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
-# Set this to fail on the install 
+# Set this to fail on the install
 set -euxo pipefail
-
-# Install and run the plugin for checkov
-# Use the full path to run pip3.10
-pip3 install checkov
 
 # List of checks we do not want to run here
 # This is a living list and will see additions and mostly removals over time.
@@ -19,7 +15,7 @@ echo "==========================================================================
 # Set not to fail on non-zero exit code
 set +e
 # Run checkov
-python3 -m checkov.main --skip-check $SKIP_CHECKS --quiet --framework terraform --compact -d .
+checkov --skip-check $SKIP_CHECKS --quiet --framework terraform --compact -d .
 
 # Options
 # --quiet: Only show failing tests

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -27,4 +27,9 @@ trap remove_pidfile EXIT
 echo $$ > "$PIDFILE"
 
 echo "Installing asdf dependencies as defined in '${WORKDIR}/.tool-versions':"
-asdf install
+if [ ! -f ".use_mise" ]; then
+  asdf install
+else
+  mise install
+  eval "$(mise activate)"
+fi

--- a/.buildkite/vagrant-run.sh
+++ b/.buildkite/vagrant-run.sh
@@ -13,23 +13,20 @@ cleanup() {
 }
 
 echo --- ":vagrant: installing plugins"
-plugins=("vagrant-google --plugin-version '2.7.0'" vagrant-env vagrant-scp)
-for i in "${plugins[@]}"; do
-  vagrant plugin list --no-tty
-	if ! vagrant plugin list --no-tty | grep "$i"; then
-		vagrant plugin install "$i"
-	fi
-done
+vagrant --version
+vagrant plugin install vagrant-google --plugin-version '2.7.0'
+vagrant plugin install vagrant-env
+vagrant plugin install vagrant-scp
 
 trap cleanup EXIT
 
-echo --- ":bug: fixing dotenv"
-echo "see fix: https://github.com/hashicorp/vagrant/issues/13550"
-sed -i -e 's/exists?/exist?/g' /var/lib/buildkite-agent/.vagrant.d/gems/3.3.8/gems/dotenv-0.11.1/lib/dotenv.rb
+# echo --- ":bug: fixing dotenv"
+# echo "see fix: https://github.com/hashicorp/vagrant/issues/13550"
+# sed -i -e 's/exists?/exist?/g' /var/lib/buildkite-agent/.vagrant.d/gems/3.3.8/gems/dotenv-0.11.1/lib/dotenv.rb
 
 echo --- ":lock: builder account key"
 KEY_PATH="/tmp/e2e-builder.json"
-if [ ! -f ${KEY_PATH} ];
+if [ ! -f ${KEY_PATH} ]; then
   gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci > "${KEY_PATH}"
 fi
 export GOOGLE_JSON_KEY_LOCATION="${KEY_PATH}"

--- a/.buildkite/vagrant-run.sh
+++ b/.buildkite/vagrant-run.sh
@@ -20,10 +20,6 @@ vagrant plugin install vagrant-scp
 
 trap cleanup EXIT
 
-# echo --- ":bug: fixing dotenv"
-# echo "see fix: https://github.com/hashicorp/vagrant/issues/13550"
-# sed -i -e 's/exists?/exist?/g' /var/lib/buildkite-agent/.vagrant.d/gems/3.3.8/gems/dotenv-0.11.1/lib/dotenv.rb
-
 echo --- ":lock: builder account key"
 KEY_PATH="/tmp/e2e-builder.json"
 if [ ! -f ${KEY_PATH} ]; then

--- a/.buildkite/vagrant-run.sh
+++ b/.buildkite/vagrant-run.sh
@@ -21,6 +21,11 @@ for i in "${plugins[@]}"; do
 done
 
 trap cleanup EXIT
+
+echo --- ":bug: fixing dotenv"
+echo "see Fix plugin: https://github.com/hashicorp/vagrant/issues/13550"
+sed -i -e 's/exists?/exist?/g' /var/lib/buildkite-agent/.vagrant.d/gems/3.3.8/gems/dotenv-0.11.1/lib/dotenv.rb
+
 echo --- ":vagrant: starting box $box"
 vagrant up "$box" --provider=google || exit_code=$?
 

--- a/.buildkite/vagrant-run.sh
+++ b/.buildkite/vagrant-run.sh
@@ -15,6 +15,7 @@ cleanup() {
 echo --- ":vagrant: installing plugins"
 plugins=(vagrant-google vagrant-env vagrant-scp)
 for i in "${plugins[@]}"; do
+  vagrant plugin list --no-tty
 	if ! vagrant plugin list --no-tty | grep "$i"; then
 		vagrant plugin install "$i"
 	fi

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,4 +3,4 @@ yarn 1.22.4
 shellcheck 0.7.1
 golang 1.19.8
 github-cli 2.46.0
-python system
+checkov

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
-nodejs 16.7.0
-yarn 1.22.4
-shellcheck 0.7.1
-golang 1.19.8
-github-cli 2.46.0
-checkov
+nodejs                   16.7.0
+yarn                     1.22.4
+shellcheck               0.7.1
+golang                   1.19.8
+github-cli               2.46.0
+asdf:bosmak/asdf-checkov latest

--- a/.use_mise
+++ b/.use_mise
@@ -1,0 +1,6 @@
+Buildkite Agent CI use the presence of this file to determine whether it should install tools with mise or install them with ASDF.
+Thus if you delete this file, CI will use ASDF to install tools and not mise.
+
+The file is only meant to be here while we transition to using mise completely.
+
+For more information you can reach out to the dev-infra team on #discuss-dev-infra.

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -62,6 +62,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         cat << EOF >> /root/.profile
 export GIT_BRANCH=#{ENV['BUILDKITE_BRANCH']}
 export TEST_TYPE=#{ENV['TEST_TYPE']}
+export DOCKER_USERNAME=#{ENV['DOCKER_USERNAME']}
+export DOCKER_PASSWORD=#{ENV['DOCKER_PASSWORD']}
 EOF
         SHELL
 

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -17,7 +17,7 @@ deploy_sourcegraph() {
 		timeout 600s ./pure-docker/deploy.sh
 		expect_containers="23"
 	elif [[ "$TEST_TYPE" == "docker-compose-test" ]]; then
-		docker-compose --file docker-compose/docker-compose.yaml up -d -t 600
+    docker-compose --file docker-compose/docker-compose.yaml up -d -t 600
 		expect_containers="25"
 	fi
 

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -2,6 +2,9 @@
 set -euxfo pipefail
 
 configure_docker() {
+  if [ -n "${DOCKER_USERNAME}" ] && [ -n "${DOCKER_PASSWORD}" ]; then
+    docker login -u "${DOCKER_USERNAME}" --password-stdin <<<"$DOCKER_PASSWORD"
+  fi
   gcloud auth configure-docker
   gcloud auth configure-docker us-central1-docker.pkg.dev
 }

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -17,7 +17,7 @@ deploy_sourcegraph() {
 		timeout 600s ./pure-docker/deploy.sh
 		expect_containers="23"
 	elif [[ "$TEST_TYPE" == "docker-compose-test" ]]; then
-    docker-compose --file docker-compose/docker-compose.yaml up -d -t 600
+		docker-compose --file docker-compose/docker-compose.yaml up -d -t 600
 		expect_containers="25"
 	fi
 


### PR DESCRIPTION
Ultimate goal: login with docker to get higher pull limits

What it involved:
- Rework how the `buildkite-agent` vm is built
  - https://github.com/sourcegraph/infrastructure/pull/6848
  - https://github.com/sourcegraph/infrastructure/pull/6849
  - https://github.com/sourcegraph/infrastructure/pull/6850
  - https://github.com/sourcegraph/infrastructure/pull/6851
  - https://github.com/sourcegraph/infrastructure/pull/6852
  - https://github.com/sourcegraph/infrastructure/pull/6854
  - https://github.com/sourcegraph/infrastructure/pull/6855
  - https://github.com/sourcegraph/infrastructure/pull/6856
- Transition to mise
- Use a specific version of vagrant (2.4.1) otherwise the an older incompatible version of `vagrant-google` (2.2.0) gets installed, 2.7.0 is the latest and correct one
- Fix vagrant issues

Closes DINF-1148

### Test plan
CI