### PR TITLE
fix: remove go from release.yaml dependency check

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -10,9 +10,6 @@ requirements:
   # We use wget here, because curl --fail-with-body was introduced in a version ulterior to what we can have on the CI agents.
   - name: "wget"
     cmd: "wget --help"
-  - name: "go"
-    cmd: "which go"
-    fixInstructions: "install golang"
   - name: "GitHub cli exists"
     cmd: "which gh"
     fixInstructions: "install GitHub cli"


### PR DESCRIPTION
<!-- description here -->
Cam across this issue when running the temporal automation for this repo.
I see no reason to have this in here, afaik we don't depend on go

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan
Run the temporal automation for deploy-sourcegraph-docker
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
