### PR TITLE
fix: update internal registry from legacy to new revamp registry

### DIFF
--- a/batch-change/release.yaml
+++ b/batch-change/release.yaml
@@ -32,34 +32,34 @@ internal:
         - name: docker(compose):tags
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
             sg ops update-images --registry ${registry} --kind compose --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD ../docker-compose/
         - name: docker(shell):tags
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
             sg ops update-images --registry ${registry} --kind pure-docker --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD ../pure-docker/
       minor:
         - name: docker(compose):tags
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
             sg ops update-images --registry ${registry} --kind compose --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD ../docker-compose/
         - name: docker(shell):tags
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
             sg ops update-images --registry ${registry} --kind pure-docker --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD ../pure-docker/
       major:
         - name: docker(compose):tags
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
             sg ops update-images --registry ${registry} --kind compose --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD ../docker-compose/
         - name: docker(shell):tags
           cmd: |
             set -eu
-            registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+            registry=us-docker.pkg.dev/sourcegraph-images/internal
             sg ops update-images --registry ${registry} --kind pure-docker --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD ../pure-docker/
   finalize:
     steps:

--- a/release.yaml
+++ b/release.yaml
@@ -31,12 +31,12 @@ internal:
           - name: docker(compose):tags
             cmd: |
               set -eu
-              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              registry=us-docker.pkg.dev/sourcegraph-images/internal
               sg ops update-images --registry ${registry} --kind compose --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD   docker-compose/
           - name: docker(shell):tags
             cmd: |
               set -eu
-              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              registry=us-docker.pkg.dev/sourcegraph-images/internal
               sg ops update-images --registry ${registry} --kind shell --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD  pure-docker/
           - name: "git:branch"
             cmd: |
@@ -57,12 +57,12 @@ internal:
           - name: docker(compose):tags
             cmd: |
               set -eu
-              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              registry=us-docker.pkg.dev/sourcegraph-images/internal
               sg ops update-images --registry ${registry} --kind compose --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD docker-compose/
           - name: docker(shell):tags
             cmd: |
               set -eu
-              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              registry=us-docker.pkg.dev/sourcegraph-images/internal
               sg ops update-images --registry ${registry} --kind shell --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD pure-docker/
           - name: "git:branch"
             cmd: |
@@ -83,12 +83,12 @@ internal:
           - name: docker(compose):tags
             cmd: |
               set -eu
-              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              registry=us-docker.pkg.dev/sourcegraph-images/internal
               sg ops update-images --registry ${registry} --kind compose --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD docker-compose/
           - name: docker(shell):tags
             cmd: |
               set -eu
-              registry=us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal
+              registry=us-docker.pkg.dev/sourcegraph-images/internal
               sg ops update-images --registry ${registry} --kind shell --pin-tag {{inputs.server.tag}} --docker-username $DOCKER_USERNAME --docker-password $DOCKER_PASSWORD pure-docker/
           - name: "git:branch"
             cmd: |


### PR DESCRIPTION
## Problem
The release creation process was failing with 404 errors when trying to fetch images like cadvisor:6.6.2517 from the legacy internal registry.

## Root Cause
Recent changes in the main sourcegraph repo migrated from legacy registries to new 'revamp' registries, but the deploy repos were still hardcoded to use the old registry.

## Solution
- Replace `us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal` with `us-docker.pkg.dev/sourcegraph-images/internal`
- Updated both release.yaml and batch-change/release.yaml
- Tested and confirmed images exist in the new registry

## Test Plan
- Validated that cadvisor:6.6.2517 exists in new registry but not in old registry
- Successfully tested sg ops update-images command with new registry
- Confirmed this fixes the original 404 errors during release creation