### PR TITLE
chore/release: deprecation notice for pure docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ We've made our deployment configurations open source to better serve our custome
 
 ## Pure-Docker Sourcegraph cluster deployment reference
 
+> ⚠️ **Deprecation Notice:** The pure-Docker deployment method is planned for deprecation.
+
 What if your organization wants a multi-machine deployment without using Kubernetes?
 What if you use a different container management platform, for example?
 Anyone using a container management platform other than Kubernetes (Netflix's [Titus](https://netflix.github.io/titus/), Apache's [Mesos](http://mesos.apache.org/documentation/latest/docker-containerizer/), etc.) can use our [Pure-Docker Sourcegraph cluster deployment reference](./pure-docker/README.md) to deploy Sourcegraph.

--- a/pure-docker/README.md
+++ b/pure-docker/README.md
@@ -1,5 +1,7 @@
 # Pure-Docker Sourcegraph cluster deployment reference
 
+> ⚠️ **Deprecation Notice:** The pure-Docker deployment method is planned for deprecation.
+
 ## Deploying
 
 First clone the repository, then:


### PR DESCRIPTION
closes PLAT-416

This just adds a deprecation notice for pure docker

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
