### PR TITLE
chore/platform: update docker-compose to support jaeger 2.16 config

### DIFF
--- a/docker-compose/jaeger/docker-compose.yaml
+++ b/docker-compose/jaeger/docker-compose.yaml
@@ -1,10 +1,10 @@
 version: '2.4'
 services:
   # Description: Jaeger all-in-one instance
-  # (https://www.jaegertracing.io/docs/1.17/getting-started/#all-in-one) for distributed tracing.
+  # (https://www.jaegertracing.io/docs/2.16/getting-started/) for distributed tracing.
   #
   # Disk: none
-  # Ports exposed to other Sourcegraph services: 5778/TCP 6831/UDP 6832/UDP 14250/TCP 4317/UDP 4321/UDP
+  # Ports exposed to other Sourcegraph services: 5778/TCP 4317/TCP 4318/TCP
   # Ports exposed to the public internet: none
   # Ports exposed to site admins only: 16686/HTTP
   #
@@ -16,23 +16,15 @@ services:
     ports:
       # Query port
       - '0.0.0.0:16686:16686'
-      # Collector port
-      - '0.0.0.0:14250:14250'
-      - '0.0.0.0:4317:4317' # gRPC port
-      - '0.0.0.0:4321:4321' # HTTP port
-      # Agent ports
+      # OTLP ports
+      - '0.0.0.0:4317:4317' # gRPC
+      - '0.0.0.0:4318:4318' # HTTP
+      # Remote sampling
       - '0.0.0.0:5778:5778'
-      - '0.0.0.0:6831:6831'
-      - '0.0.0.0:6832:6832'
     networks:
       - sourcegraph
     restart: always
-    command: ['--memory.max-traces=20000', "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json", "--collector.otlp.enabled" ]
-    environment:
-      - 'SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json'
-      - 'COLLECTOR_OTLP_ENABLED=true'
-      - 'JAEGER_OTLP_GRPC_PORT=4317'
-      - 'JAEGER_OTLP_HTTP_PORT=4321'
+    command: ['--config=/etc/jaeger/jaeger-config.yaml']
 
   # Configure collector to send traces to Jaeger
   otel-collector:


### PR DESCRIPTION
closes PLAT-487

Update manifests to support 2.16 jaeger configurations style

This follows changes to the sourcegraph jaeger base image https://github.com/sourcegraph/sourcegraph/pull/10912

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] Sister [customer-replica](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1) change (if necessary, for any changes affecting pure-docker or configuration):
* [ ] All images have a valid tag and SHA256 sum
### Test plan

This was tested with a local deployment of docker compose, switching in the new jaeger image and the config changes here.

Then a search and trace were performed
<img width="2483" height="1505" alt="Screenshot 2026-03-19 at 10 33 48 AM" src="https://github.com/user-attachments/assets/f5f6e5bf-f759-4663-8701-0c6f88e1087b" />

<img width="2541" height="857" alt="Screenshot 2026-03-19 at 10 31 56 AM" src="https://github.com/user-attachments/assets/1383df54-f997-47f2-931d-7eef19012ec1" />


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
