### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/.buildkite/verify-release/go.mod
+++ b/.buildkite/verify-release/go.mod
@@ -1,5 +1,5 @@
 module verify-release
 
-go 1.16
+go 1.26.4
 
 require golang.org/x/mod v0.4.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 nodejs                   16.7.0
 yarn                     1.22.4
 shellcheck               0.7.1
-golang                   1.19.8
+golang                   1.26.4
 github-cli               2.46.0
 asdf:bosmak/asdf-checkov latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/deploy-sourcegraph-docker
 
-go 1.19
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)