### PR TITLE
fix: update v7.5.4453 Docker Compose image manifests

### DIFF
--- a/docker-compose/db-only-migrate.docker-compose.yaml
+++ b/docker-compose/db-only-migrate.docker-compose.yaml
@@ -13,7 +13,7 @@ services:
   #
   pgsql:
     container_name: pgsql
-    image: 'index.docker.io/sourcegraph/postgresql-16:6.0.0@sha256:224a2604331cb73809f466394c5b4f3ca95bf6a5a140cb75820dfe67301074bb'
+    image: 'index.docker.io/sourcegraph/postgresql-16:7.5.4453@sha256:c287f49fdf847eeffb25481e614454ade57aee4aafe2774d260aec070176fa78'
     cpus: 4
     mem_limit: '2g'
     healthcheck:
@@ -30,7 +30,7 @@ services:
 
   codeintel-db:
     container_name: codeintel-db
-    image: 'index.docker.io/sourcegraph/postgresql-16:6.0.0@sha256:224a2604331cb73809f466394c5b4f3ca95bf6a5a140cb75820dfe67301074bb'
+    image: 'index.docker.io/sourcegraph/postgresql-16:7.5.4453@sha256:c287f49fdf847eeffb25481e614454ade57aee4aafe2774d260aec070176fa78'
     cpus: 4
     mem_limit: '2g'
     healthcheck:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
   # for this container will need to be updated to reflect the new connection information.
   migrator:
     container_name: migrator
-    image: 'index.docker.io/sourcegraph/migrator:6.1.2889@sha256:67b5b187f006bb789898cd1ab02fd82f860fe1511524a416ba63ee71ebd603c6'
+    image: 'index.docker.io/sourcegraph/migrator:7.5.4453@sha256:8a0c3a3cb5f3b7a0e56a171b6ce05b7a149b8b91286394dc8cd4727a0da3999e'
     cpus: 0.5
     mem_limit: '500m'
     command: ['up']
@@ -69,7 +69,7 @@ services:
   # https://caddyserver.com/docs/caddyfile
   caddy:
     container_name: caddy
-    image: 'index.docker.io/sourcegraph/caddy:6.1.2889@sha256:26443b2905169ec27efba3c090d9c04e0c0779d7fb4001cbdcbe32ec1598eb59'
+    image: 'index.docker.io/sourcegraph/caddy:7.5.4453@sha256:311363c79a71cfb79922fc98301866ebb56e30d5ddb9f4bfca1ade1fbe3b4858'
     cpus: 4
     mem_limit: '4g'
     environment:
@@ -124,7 +124,7 @@ services:
   # service.
   sourcegraph-frontend-0:
     container_name: sourcegraph-frontend-0
-    image: 'index.docker.io/sourcegraph/frontend:6.1.2889@sha256:43dad562a65d08842659abdd06cf3c92d3745cc9e18c3762e458b78028a86e1e'
+    image: 'index.docker.io/sourcegraph/frontend:7.5.4453@sha256:f0628e99ffcd12db5dc54eed7e3b81f8f07b35b2dca93a0773aa4d48f06b11ed'
     cpus: 4
     mem_limit: '8g'
     environment:
@@ -177,7 +177,7 @@ services:
   #
   sourcegraph-frontend-internal:
     container_name: sourcegraph-frontend-internal
-    image: 'index.docker.io/sourcegraph/frontend:6.1.2889@sha256:43dad562a65d08842659abdd06cf3c92d3745cc9e18c3762e458b78028a86e1e'
+    image: 'index.docker.io/sourcegraph/frontend:7.5.4453@sha256:f0628e99ffcd12db5dc54eed7e3b81f8f07b35b2dca93a0773aa4d48f06b11ed'
     cpus: 4
     mem_limit: '8g'
     environment:
@@ -223,7 +223,7 @@ services:
   #
   gitserver-0:
     container_name: gitserver-0
-    image: 'index.docker.io/sourcegraph/gitserver:6.1.2889@sha256:282142b7886f58b0ea7251575c92d5c837ff8649d5831c9c52745ebed6f3af4f'
+    image: 'index.docker.io/sourcegraph/gitserver:7.5.4453@sha256:f2dbd482247d160cb2763f200eaa9931c04e0eb3ddf92b0c3c75bd55f79d019c'
     cpus: 4
     mem_limit: '8g'
     environment:
@@ -246,7 +246,7 @@ services:
   #
   zoekt-indexserver-0:
     container_name: zoekt-indexserver-0
-    image: 'index.docker.io/sourcegraph/search-indexer:6.1.2889@sha256:8a79ecf88f4f22ff72c8a50f33a2d43506c44deddf6ef2e43d8101af9ccd97c0'
+    image: 'index.docker.io/sourcegraph/search-indexer:7.5.4453@sha256:75a831098b20c25c28e1c4b265eeb85b71757f4d5d11a2627d6cf896902eeec5'
     cpus: 8
     mem_limit: '16g'
     environment:
@@ -269,7 +269,7 @@ services:
   #
   zoekt-webserver-0:
     container_name: zoekt-webserver-0
-    image: 'index.docker.io/sourcegraph/indexed-searcher:6.1.2889@sha256:9bb181a003811fb0193c4fa594ded800f2f155752829f1c4f97a7bfa37dbe69e'
+    image: 'index.docker.io/sourcegraph/indexed-searcher:7.5.4453@sha256:2cabbb14f98f84d9ef1c4a83201beea9c0d783737a4a388d4c5870582c05967e'
     cpus: 8
     mem_limit: '50g'
     environment:
@@ -296,7 +296,7 @@ services:
   #
   searcher-0:
     container_name: searcher-0
-    image: 'index.docker.io/sourcegraph/searcher:6.1.2889@sha256:66f633e4e666d65684915087009bdbdb8a46dad6eccb4c307a6de141e0225be6'
+    image: 'index.docker.io/sourcegraph/searcher:7.5.4453@sha256:dcdf9706101f5849ef24539896f9b3e60ca6a4ba906addf66b6ce299fac91ac7'
     cpus: 2
     mem_limit: '2g'
     environment:
@@ -320,7 +320,7 @@ services:
   #
   precise-code-intel-worker:
     container_name: precise-code-intel-worker
-    image: 'index.docker.io/sourcegraph/precise-code-intel-worker:6.1.2889@sha256:2a8ec49e080ff19e6f05f92c39cfc67ac50b8e2ff5aba4dcbd7451bba1e8d539'
+    image: 'index.docker.io/sourcegraph/precise-code-intel-worker:7.5.4453@sha256:443f2e6e3d0af65d8f3d2990ba88b386315fb9c9c59adc91baa64a55667873a0'
     cpus: 2
     mem_limit: '4g'
     environment:
@@ -346,7 +346,7 @@ services:
   #
   worker:
     container_name: worker
-    image: 'index.docker.io/sourcegraph/worker:6.1.2889@sha256:1ef615670e315edda8511ab1e06ffd27b98129bc962bf06aca455c7731baf482'
+    image: 'index.docker.io/sourcegraph/worker:7.5.4453@sha256:49a666bff68d107d1fdc03470fd144a9ceb8b9da0faa7a191dd0da530956f22c'
     cpus: 4
     mem_limit: '4g'
     environment:
@@ -371,7 +371,7 @@ services:
   #
   syntactic-code-intel-worker:
     container_name: syntactic-code-intel-worker
-    image: 'index.docker.io/sourcegraph/syntactic-code-intel-worker:6.1.1295@sha256:c6e2b097b8f16394e339588e208c43587f1fa6a35cb44e9759622c448ddc1445'
+    image: 'index.docker.io/sourcegraph/syntactic-code-intel-worker:7.5.4453@sha256:379ecf86e0488466ed2345a97d3dfaf1a9e10aa832942a74cda424ca9ed695eb'
     cpus: 2
     mem_limit: '4g'
     environment:
@@ -398,7 +398,7 @@ services:
   #
   syntect-server:
     container_name: syntect-server
-    image: 'index.docker.io/sourcegraph/syntax-highlighter:6.1.2889@sha256:eea296267ca84c8d06eb9c1e44fd5f4c4fbb3f0490193517cc3764d558a773c6'
+    image: 'index.docker.io/sourcegraph/syntax-highlighter:7.5.4453@sha256:b0a8cba42d5d629109b4591f6a4009ae887318b670603fedb65fee81d1b817f0'
     cpus: 4
     mem_limit: '6g'
     healthcheck:
@@ -419,7 +419,7 @@ services:
   #
   prometheus:
     container_name: prometheus
-    image: 'index.docker.io/sourcegraph/prometheus:6.1.2889@sha256:75fa45933ecb03f7aca1d54ec5ebc05d11ff300494a2ca8fbaefa25c83f0326f'
+    image: 'index.docker.io/sourcegraph/prometheus:7.5.4453@sha256:a3414f655ce25292e31219f695f9a2d740ee16c31aff8007c12a61c5c05340f6'
     cpus: 4
     mem_limit: '8g'
     volumes:
@@ -446,7 +446,7 @@ services:
   # 'GF_SERVER_ROOT_URL='https://grafana.example.com'
   grafana:
     container_name: grafana
-    image: 'index.docker.io/sourcegraph/grafana:6.3.3@sha256:2f68b9b1542e7d75459d983b606d2fdd1c11a75610464e3d7a6ced4f3ac474bf'
+    image: 'index.docker.io/sourcegraph/grafana:7.5.4453@sha256:df250d7ca343c836c6dc38b151a4c3fe6c7a4489c25e130e36c3708c6cce0c90'
     cpus: 1
     mem_limit: '1g'
     volumes:
@@ -465,7 +465,7 @@ services:
   #
   cadvisor:
     container_name: cadvisor
-    image: 'index.docker.io/sourcegraph/cadvisor:6.1.2889@sha256:c13394cf2de03154dd48e78129bf3d4cc31854ab98dedafd3901b413d54b4822'
+    image: 'index.docker.io/sourcegraph/cadvisor:7.5.4453@sha256:9d2652e3b05e371d30abd18fadb4450d480d70f95c7fdc064a73d4ab1dd787a9'
     cpus: 1
     mem_limit: '1g'
     # You may set `privileged` to `false and `cadvisor` will run with reduced privileges.
@@ -498,7 +498,7 @@ services:
   #
   node-exporter:
     container_name: node-exporter
-    image: 'index.docker.io/sourcegraph/node-exporter:6.1.2889@sha256:e496aa37a1053cd59f0025c232fd58261ae08d934269870a343061c7a9596bfd'
+    image: 'index.docker.io/sourcegraph/node-exporter:7.5.4453@sha256:ae1ad1a5008de94e418019badf4535d5d0b2e7950410074c66346f99bf27519d'
     cpus: .5
     mem_limit: '1g'
     pid: 'host'
@@ -527,7 +527,7 @@ services:
   #
   pgsql:
     container_name: pgsql
-    image: 'index.docker.io/sourcegraph/postgresql-16:6.1.2889@sha256:8cb7b0f54c7ab464f8e3b26918a70bebcb060219dd0b91084209563238ec1dd5'
+    image: 'index.docker.io/sourcegraph/postgresql-16:7.5.4453@sha256:c287f49fdf847eeffb25481e614454ade57aee4aafe2774d260aec070176fa78'
     cpus: 4
     mem_limit: '4g'
     shm_size: '1g'
@@ -555,7 +555,7 @@ services:
   # for this container will need to be updated to reflect the new connection information.
   pgsql-exporter:
     container_name: pgsql-exporter
-    image: 'index.docker.io/sourcegraph/postgres_exporter:6.1.2889@sha256:a2fedb3d4aa845375d3c60f37e2813d095c6718c2afa96c2bcc8c17dc8b73991'
+    image: 'index.docker.io/sourcegraph/postgres_exporter:7.5.4453@sha256:866af1c481b1facaddf1f06d317f10f25b82dd294e45e20df9fb1cb59bbdf272'
     cpus: 0.1
     mem_limit: '50m'
     networks:
@@ -574,7 +574,7 @@ services:
   #
   codeintel-db:
     container_name: codeintel-db
-    image: 'index.docker.io/sourcegraph/postgresql-16:6.1.2889@sha256:8cb7b0f54c7ab464f8e3b26918a70bebcb060219dd0b91084209563238ec1dd5'
+    image: 'index.docker.io/sourcegraph/postgresql-16:7.5.4453@sha256:c287f49fdf847eeffb25481e614454ade57aee4aafe2774d260aec070176fa78'
     cpus: 4
     mem_limit: '4g'
     shm_size: '1g'
@@ -602,7 +602,7 @@ services:
   # for this container will need to be updated to reflect the new connection information.
   codeintel-db-exporter:
     container_name: codeintel-db-exporter
-    image: 'index.docker.io/sourcegraph/postgres_exporter:6.1.2889@sha256:a2fedb3d4aa845375d3c60f37e2813d095c6718c2afa96c2bcc8c17dc8b73991'
+    image: 'index.docker.io/sourcegraph/postgres_exporter:7.5.4453@sha256:866af1c481b1facaddf1f06d317f10f25b82dd294e45e20df9fb1cb59bbdf272'
     cpus: 0.1
     mem_limit: '50m'
     networks:
@@ -621,7 +621,7 @@ services:
   #
   codeinsights-db:
     container_name: codeinsights-db
-    image: 'index.docker.io/sourcegraph/postgresql-16-codeinsights:6.1.2889@sha256:7d84febae82181e096f79e26f6459e86fa66a40ccbe30ff0f37cb118707e4e2a'
+    image: 'index.docker.io/sourcegraph/postgresql-16-codeinsights:7.5.4453@sha256:b25f899f00734b28b35be26285733b0a4a6fea07e02d5d8f2e9291cac4884100'
     cpus: 4
     mem_limit: '2g'
     shm_size: '1g'
@@ -654,7 +654,7 @@ services:
   # for this container will need to be updated to reflect the new connection information.
   codeinsights-db-exporter:
     container_name: codeinsights-db-exporter
-    image: 'index.docker.io/sourcegraph/postgres_exporter:6.1.2889@sha256:a2fedb3d4aa845375d3c60f37e2813d095c6718c2afa96c2bcc8c17dc8b73991'
+    image: 'index.docker.io/sourcegraph/postgres_exporter:7.5.4453@sha256:866af1c481b1facaddf1f06d317f10f25b82dd294e45e20df9fb1cb59bbdf272'
     cpus: 0.1
     mem_limit: '50m'
     networks:
@@ -673,7 +673,7 @@ services:
   #
   blobstore:
     container_name: blobstore
-    image: 'index.docker.io/sourcegraph/blobstore:6.1.2889@sha256:8f49a897d7f7ad4655df9cd79959620ddb73406adccccd567c4846aa24ec4a01'
+    image: 'index.docker.io/sourcegraph/blobstore:7.5.4453@sha256:cecf3abc30ef26e8c2f0f297778ce2e5c2641ba6687c097e8f21dd0ae4fc462b'
     cpus: 1
     mem_limit: '1g'
     healthcheck:
@@ -696,7 +696,7 @@ services:
   #
   redis-cache:
     container_name: redis-cache
-    image: 'index.docker.io/sourcegraph/redis-cache:6.1.2889@sha256:204c164bc59119cde8b8d19a640897e8ffe008e040b730bed2188f28fca0d31c'
+    image: 'index.docker.io/sourcegraph/redis-cache:7.5.4453@sha256:3e528499ad1ba3a56bb625386b03b12d51550f0be005a475e4ead8d936d8be53'
     cpus: 1
     mem_limit: '7g'
     volumes:
@@ -712,7 +712,7 @@ services:
   #
   redis-store:
     container_name: redis-store
-    image: 'index.docker.io/sourcegraph/redis-store:6.1.2889@sha256:4f4dfb3074e586b7eb8ab2ba631285aeb5e018452219e2f1a2f235c85b8de4bc'
+    image: 'index.docker.io/sourcegraph/redis-store:7.5.4453@sha256:fed88fe64f23b390f8f2ae8d4fe9052a2f02adfc54cb1090d31df27cf8781f1e'
     cpus: 1
     mem_limit: '7g'
     volumes:
@@ -727,7 +727,7 @@ services:
   # Ports exposed to the public internet: none
   otel-collector:
     container_name: otel-collector
-    image: 'index.docker.io/sourcegraph/opentelemetry-collector:6.1.2889@sha256:c05e84380dd81d74ff952f73d132710dc4a162fa26c0a0709fba58dcb2829958'
+    image: 'index.docker.io/sourcegraph/opentelemetry-collector:7.5.4453@sha256:18fc34f101aec65403e7ca289a68ae7ab59718b5c11e832d3a72284e39d95100'
     cpus: 1
     mem_limit: '1g'
     networks:


### PR DESCRIPTION
## Summary

- update both release-managed Docker Compose manifests to public Sourcegraph 7.5.4453 images
- pin each image to its promoted digest
- repair the `release-v7.5.4453` branch before moving tag `v7.5.4453` to the corrected branch head

## Impact

The current `v7.5.4453` tag contains stale Docker Compose image references, including Sourcegraph 6.1 and PostgreSQL 6.0 images. Users checking out the 7.5.4453 tag therefore do not receive the images produced for the 7.5.4453 search release.

## What happened

The Temporal `UpdateDockerImages` activity completed successfully and reported both expected files as updated. It created commit `d20cc5d6f1da12a6872fa968b9f927c18cc904c6` (`Update compose images to v7.5.4453`). That commit contains the expected internal image changes, but it is no longer reachable from the release branch.

One second later, the workflow created the empty Buildkite configuration commit `7e757fd508c04ea857580b1438c7108602eaca2d`. Both commits have the same parent, `31be4b977b9b9c28f9ccc4a4a2a188a972ab0f54`, rather than the configuration commit having the image-update commit as its parent:

```
31be4b
├── d20cc5d  Update compose images to v7.5.4453 (orphaned)
└── 7e757fd  release: v7.5.4453                 (branch head)
```

Our hypothesis is that the GitHub ref read performed by the configuration-commit activity briefly returned the old branch head after the image activity had updated it. The configuration commit was consequently created from the stale parent. The workflow then force-updated the branch ref, replacing the image commit instead of advancing from it.

This matches the implementation: the generic commit input supports an explicit `ParentCommitSHA` to avoid GitHub eventual-consistency races, but the empty configuration-commit path fetches the branch head again and does not chain directly from the image activity result. The ref update is also forced, allowing a stale, non-fast-forward commit to silently replace the previous branch head.

This would explain why prior releases worked: the race depends on whether the updated GitHub ref is visible before the immediately following activity reads it. The k8s workflow performs multiple commits and has more time between its first update and configuration commit.

## Follow-up

After this PR merges, move tag `v7.5.4453` to the merged `release-v7.5.4453` branch head so checkouts of the tag receive these corrected manifests.

The workflow should separately be hardened by explicitly chaining the configuration commit from the image-update commit and avoiding forced ref updates for normal sequential commits.

## Test plan

- verified the PR changes only the two manifests processed by `UpdateDockerImages`
- verified all Sourcegraph image references use tag `7.5.4453` and pinned public digests
- verified the promoted digests against the k8s release manifests; verified the caddy digest directly against Docker Hub
- ran `git diff --check`
