### PR TITLE
searcher: use debug server readiness endpoint

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -303,7 +303,7 @@ services:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
       - 'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317'
     healthcheck:
-      test: "wget -q 'http://127.0.0.1:3181/healthz' -O /dev/null || exit 1"
+      test: "wget -q 'http://127.0.0.1:6060/ready' -O /dev/null || exit 1"
       interval: 5s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Update the searcher container healthcheck to use its readiness-gated debugserver endpoint at `http://127.0.0.1:6060/ready` instead of `http://127.0.0.1:3181/healthz`.

Sister changes:

- [deploy-sourcegraph-helm#938](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/938)
- [deploy-sourcegraph-k8s#478](https://github.com/sourcegraph/deploy-sourcegraph-k8s/pull/478)

### Checklist

* [x] All images have a valid tag and SHA256 sum

### Test plan

- Ran `.buildkite/validate-docker-compose.sh` with Docker Compose 1.29.2; configuration validation passed.
- Ran `yarn -s run prettier --write=false`; formatting passed.
- The coordinated Helm change was validated with a real searcher container in a disposable kind cluster: Kubernetes marked it Ready and an in-cluster request to `/ready` returned HTTP 200.