### PR TITLE
Use debugserver for code intel worker health

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -315,7 +315,7 @@ services:
 
   # Description: Handles conversion of uploaded precise code intelligence bundles.
   #
-  # Ports exposed to other Sourcegraph services: 3188/TCP
+  # Ports exposed to other Sourcegraph services: 6060/TCP
   # Ports exposed to the public internet: none
   #
   precise-code-intel-worker:
@@ -329,7 +329,7 @@ services:
       - 'PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT=http://blobstore:9000'
       - 'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317'
     healthcheck:
-      test: "wget -q 'http://127.0.0.1:3188/healthz' -O /dev/null || exit 1"
+      test: "wget -q 'http://127.0.0.1:6060/ready' -O /dev/null || exit 1"
       interval: 5s
       timeout: 5s
       retries: 3

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -366,7 +366,7 @@ services:
   # Description: High level syntax analysis
   #
   # Disk: none
-  # Ports exposed to other Sourcegraph services: 3188/TCP
+  # Ports exposed to other Sourcegraph services: 6060/TCP
   # Ports exposed to the public internet: none
   #
   syntactic-code-intel-worker:
@@ -379,9 +379,8 @@ services:
       - 'PRECISE_CODE_INTEL_UPLOAD_BACKEND=blobstore'
       - 'PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT=http://blobstore:9000'
       - 'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317'
-      - 'SYNTACTIC_CODE_INTEL_WORKER_ADDR=:3288'
     healthcheck:
-      test: "wget -q 'http://127.0.0.1:3288/healthz' -O /dev/null || exit 1"
+      test: "wget -q 'http://127.0.0.1:6060/ready' -O /dev/null || exit 1"
       interval: 5s
       timeout: 15s
       retries: 3


### PR DESCRIPTION
The precise and syntactic code intel workers already report readiness from their debugservers on port 6060. Point both Docker healthchecks there and remove the obsolete syntactic worker address configuration, aligning Docker Compose with the Kubernetes deployments.