### PR TITLE
Configure shared object storage

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -6,16 +6,10 @@ To learn more about deploying, configuring, and upgrading a Sourcegraph with Doc
 
 ## Shared object storage
 
-[`sourcegraph-uploads.env`](sourcegraph-uploads.env) configures shared Sourcegraph object storage for six services: frontend (both frontend containers), worker, precise Code Intel, syntactic Code Intel, gitserver, and searcher. It uses the bundled blobstore by default.
+Sourcegraph requires an object storage to work. [Learn more](https://sourcegraph.com/docs/self-hosted/external-services/object-storage#sourcegraph-bucket).
 
-To use an external S3 or GCS bucket, update that file so every consumer receives the same settings. Containers do not inherit environment variables or cloud credentials from the host or from other containers, so credentials must be provided explicitly in this file (or by an equivalent Compose override applied to every consumer).
+[`sourcegraph-uploads.env`](sourcegraph-uploads.env) configures shared Sourcegraph object storage for six services: frontend, worker, precise code intel, syntactic code intel, gitserver, and searcher. It uses a bundled blobstore by default to get you started, but we strongly recommend using S3 or GCS.
 
-Common settings are:
-
-- `SOURCEGRAPH_UPLOAD_BACKEND`: `S3`, `GCS`, or `blobstore`
-- `SOURCEGRAPH_UPLOAD_BUCKET`
-- `SOURCEGRAPH_UPLOAD_MANAGE_BUCKET`
-- S3: `SOURCEGRAPH_UPLOAD_AWS_REGION`, `SOURCEGRAPH_UPLOAD_AWS_ENDPOINT`, `SOURCEGRAPH_UPLOAD_AWS_USE_PATH_STYLE`, `SOURCEGRAPH_UPLOAD_AWS_ACCESS_KEY_ID`, `SOURCEGRAPH_UPLOAD_AWS_SECRET_ACCESS_KEY`, and optionally `SOURCEGRAPH_UPLOAD_AWS_SESSION_TOKEN` or `SOURCEGRAPH_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS`
-- GCS: `SOURCEGRAPH_UPLOAD_GCP_PROJECT_ID` and `SOURCEGRAPH_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT`
+To use an external S3 or GCS bucket, update that file with the correct settings.
 
 For GCS, embedding the service-account JSON with `SOURCEGRAPH_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT` avoids requiring an identical credential-file mount in every container. If `SOURCEGRAPH_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE` is used instead, mount that path into every consumer.

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -3,3 +3,19 @@
 This directory contains the Sourcegraph with Docker Compose deployment reference.
 
 To learn more about deploying, configuring, and upgrading a Sourcegraph with Docker Compose installation, please refer to our documentation: [Sourcegraph with Docker Compose](https://docs.sourcegraph.com/admin/install/docker-compose)
+
+## Shared object storage
+
+[`sourcegraph-uploads.env`](sourcegraph-uploads.env) configures shared Sourcegraph object storage for six services: frontend (both frontend containers), worker, precise Code Intel, syntactic Code Intel, gitserver, and searcher. It uses the bundled blobstore by default.
+
+To use an external S3 or GCS bucket, update that file so every consumer receives the same settings. Containers do not inherit environment variables or cloud credentials from the host or from other containers, so credentials must be provided explicitly in this file (or by an equivalent Compose override applied to every consumer).
+
+Common settings are:
+
+- `SOURCEGRAPH_UPLOAD_BACKEND`: `S3`, `GCS`, or `blobstore`
+- `SOURCEGRAPH_UPLOAD_BUCKET`
+- `SOURCEGRAPH_UPLOAD_MANAGE_BUCKET`
+- S3: `SOURCEGRAPH_UPLOAD_AWS_REGION`, `SOURCEGRAPH_UPLOAD_AWS_ENDPOINT`, `SOURCEGRAPH_UPLOAD_AWS_USE_PATH_STYLE`, `SOURCEGRAPH_UPLOAD_AWS_ACCESS_KEY_ID`, `SOURCEGRAPH_UPLOAD_AWS_SECRET_ACCESS_KEY`, and optionally `SOURCEGRAPH_UPLOAD_AWS_SESSION_TOKEN` or `SOURCEGRAPH_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS`
+- GCS: `SOURCEGRAPH_UPLOAD_GCP_PROJECT_ID` and `SOURCEGRAPH_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT`
+
+For GCS, embedding the service-account JSON with `SOURCEGRAPH_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT` avoids requiring an identical credential-file mount in every container. If `SOURCEGRAPH_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE` is used instead, mount that path into every consumer.

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -127,6 +127,7 @@ services:
     image: 'index.docker.io/sourcegraph/frontend:6.1.2889@sha256:43dad562a65d08842659abdd06cf3c92d3745cc9e18c3762e458b78028a86e1e'
     cpus: 4
     mem_limit: '8g'
+    env_file: sourcegraph-uploads.env
     environment:
       - DEPLOY_TYPE=docker-compose
       - 'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317'
@@ -180,6 +181,7 @@ services:
     image: 'index.docker.io/sourcegraph/frontend:6.1.2889@sha256:43dad562a65d08842659abdd06cf3c92d3745cc9e18c3762e458b78028a86e1e'
     cpus: 4
     mem_limit: '8g'
+    env_file: sourcegraph-uploads.env
     environment:
       - DEPLOY_TYPE=docker-compose
       - PGHOST=pgsql
@@ -226,6 +228,7 @@ services:
     image: 'index.docker.io/sourcegraph/gitserver:6.1.2889@sha256:282142b7886f58b0ea7251575c92d5c837ff8649d5831c9c52745ebed6f3af4f'
     cpus: 4
     mem_limit: '8g'
+    env_file: sourcegraph-uploads.env
     environment:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
       - 'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317'
@@ -299,6 +302,7 @@ services:
     image: 'index.docker.io/sourcegraph/searcher:6.1.2889@sha256:66f633e4e666d65684915087009bdbdb8a46dad6eccb4c307a6de141e0225be6'
     cpus: 2
     mem_limit: '2g'
+    env_file: sourcegraph-uploads.env
     environment:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
       - 'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317'
@@ -323,6 +327,7 @@ services:
     image: 'index.docker.io/sourcegraph/precise-code-intel-worker:6.1.2889@sha256:2a8ec49e080ff19e6f05f92c39cfc67ac50b8e2ff5aba4dcbd7451bba1e8d539'
     cpus: 2
     mem_limit: '4g'
+    env_file: sourcegraph-uploads.env
     environment:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
       - 'PRECISE_CODE_INTEL_UPLOAD_BACKEND=blobstore'
@@ -349,6 +354,7 @@ services:
     image: 'index.docker.io/sourcegraph/worker:6.1.2889@sha256:1ef615670e315edda8511ab1e06ffd27b98129bc962bf06aca455c7731baf482'
     cpus: 4
     mem_limit: '4g'
+    env_file: sourcegraph-uploads.env
     environment:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
       - 'OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317'
@@ -374,6 +380,7 @@ services:
     image: 'index.docker.io/sourcegraph/syntactic-code-intel-worker:6.1.1295@sha256:c6e2b097b8f16394e339588e208c43587f1fa6a35cb44e9759622c448ddc1445'
     cpus: 2
     mem_limit: '4g'
+    env_file: sourcegraph-uploads.env
     environment:
       - 'SRC_FRONTEND_INTERNAL=sourcegraph-frontend-internal:3090'
       - 'PRECISE_CODE_INTEL_UPLOAD_BACKEND=blobstore'

--- a/docker-compose/sourcegraph-uploads.env
+++ b/docker-compose/sourcegraph-uploads.env
@@ -1,0 +1,6 @@
+# Shared Sourcegraph object storage. These values use the bundled blobstore.
+SOURCEGRAPH_UPLOAD_BACKEND=blobstore
+SOURCEGRAPH_UPLOAD_AWS_ENDPOINT=http://blobstore:9000
+
+# To use external S3 or GCS, replace the settings above and provide every
+# container with credentials here. See README.md for supported settings.


### PR DESCRIPTION
Adds documentation and a config template for the Sourcegraph shared object storage, and sets it on all services that require it.